### PR TITLE
fix: switch to gemini-2.5-flash-lite model

### DIFF
--- a/api/internal/chat/handler.go
+++ b/api/internal/chat/handler.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 )
 
@@ -40,6 +41,7 @@ func NewHandler(provider Provider) http.Handler {
 
 		response, err := provider.GenerateResponse(r.Context(), SystemPrompt(), req.Messages)
 		if err != nil {
+			log.Printf("Chat error: %v", err)
 			http.Error(w, `{"error":"failed to generate response"}`, http.StatusInternalServerError)
 			return
 		}

--- a/api/internal/chat/provider.go
+++ b/api/internal/chat/provider.go
@@ -25,7 +25,7 @@ type GeminiProvider struct {
 
 func NewGeminiProvider(apiKey, model string) *GeminiProvider {
 	if model == "" {
-		model = "gemini-2.0-flash"
+		model = "gemini-2.5-flash-lite"
 	}
 	return &GeminiProvider{APIKey: apiKey, Model: model}
 }


### PR DESCRIPTION
Replace deprecated gemini-2.0-flash-lite with gemini-2.5-flash-lite and add error logging to chat handler.