### PR TITLE
Fix contact form 404 and add success page

### DIFF
--- a/frontend/src/components/Contact.astro
+++ b/frontend/src/components/Contact.astro
@@ -7,7 +7,7 @@ import SectionHeader from './SectionHeader.astro';
     <SectionHeader number="04" label="CONTACT" title="Let's Connect" />
 
     <div class="grid md:grid-cols-2 gap-12 mt-8">
-      <form name="contact" method="POST" data-netlify="true" netlify-honeypot="bot-field" class="space-y-5">
+      <form name="contact" method="POST" action="/success" data-netlify="true" netlify-honeypot="bot-field" class="space-y-5">
         <input type="hidden" name="form-name" value="contact" />
         <p class="hidden">
           <label>Don't fill this out: <input name="bot-field" /></label>

--- a/frontend/src/pages/success.astro
+++ b/frontend/src/pages/success.astro
@@ -1,0 +1,25 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Nav from '../components/Nav.astro';
+import Footer from '../components/Footer.astro';
+---
+
+<BaseLayout title="Message Sent | Rafael Abreu">
+  <Nav />
+  <main class="min-h-[70vh] flex items-center justify-center px-6">
+    <div class="text-center max-w-md">
+      <div class="font-mono text-xs text-accent-indigo tracking-wider mb-4">MESSAGE SENT</div>
+      <h1 class="text-3xl md:text-4xl mb-4">Thank you!</h1>
+      <p class="text-text-secondary text-sm leading-relaxed mb-8">
+        Your message has been received. I'll get back to you as soon as I can.
+      </p>
+      <a
+        href="/"
+        class="inline-block px-8 py-3 bg-accent-indigo rounded-btn text-white text-sm font-semibold hover:bg-accent-indigo/90 transition-colors duration-200"
+      >
+        Back to Home
+      </a>
+    </div>
+  </main>
+  <Footer />
+</BaseLayout>


### PR DESCRIPTION
## Summary
- Adds `action="/success"` to the Netlify contact form — previously missing, causing a 404 after submission
- Creates a `/success` thank-you page matching the site's design (Nav, Footer, centered confirmation message)

## Required: Enable Netlify Form Detection
Form submissions were never received because **form detection is disabled** in Netlify site settings. After merging:
1. Go to Netlify > Site Settings > Forms > click **"Enable form detection"**
2. Optionally add an email notification under Forms > Form notifications

## Test plan
- [ ] Deploy to Netlify
- [ ] Enable form detection in Netlify UI
- [ ] Submit the contact form with test data
- [ ] Verify redirect lands on `/success` page
- [ ] Verify submission appears in Netlify dashboard (Forms section)
- [ ] Optionally configure email notification and verify delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)