### PR TITLE
feat: dark/light theme toggle (P7)

### DIFF
--- a/frontend/src/components/Hero.astro
+++ b/frontend/src/components/Hero.astro
@@ -42,7 +42,7 @@ const tags: { label: string; color: 'indigo' | 'purple' | 'pink' }[] = [
       </a>
       <button
         id="hero-chat-trigger"
-        class="px-6 py-2.5 border border-white/15 rounded-btn text-gray-300 text-sm font-medium hover:border-accent-indigo/40 hover:text-accent-indigo transition-colors duration-200"
+        class="px-6 py-2.5 border border-surface-border rounded-btn text-text-secondary text-sm font-medium hover:border-accent-indigo/40 hover:text-accent-indigo transition-colors duration-200"
       >
         Ask my AI →
       </button>

--- a/frontend/src/components/Nav.astro
+++ b/frontend/src/components/Nav.astro
@@ -3,11 +3,11 @@ import MobileNav from '../islands/MobileNav.tsx';
 import ThemeToggle from '../islands/ThemeToggle.tsx';
 
 const navItems = [
-  { label: 'About', href: '#about' },
-  { label: 'Projects', href: '#projects' },
-  { label: 'Skills', href: '#skills' },
+  { label: 'About', href: '/#about' },
+  { label: 'Projects', href: '/#projects' },
+  { label: 'Skills', href: '/#skills' },
   { label: 'Playground', href: '/playground' },
-  { label: 'Contact', href: '#contact' },
+  { label: 'Contact', href: '/#contact' },
 ];
 
 const resumePath = '/Rafael_Abreu_Resume.pdf';
@@ -41,7 +41,7 @@ const resumePath = '/Rafael_Abreu_Resume.pdf';
         RESUME
       </a>
       <a
-        href="#contact"
+        href="/#contact"
         class="px-4 py-1.5 bg-accent-indigo rounded-btn text-white text-xs tracking-wide hover:bg-accent-indigo/90 transition-colors duration-200"
       >
         LET'S TALK

--- a/frontend/src/components/Nav.astro
+++ b/frontend/src/components/Nav.astro
@@ -1,5 +1,6 @@
 ---
 import MobileNav from '../islands/MobileNav.tsx';
+import ThemeToggle from '../islands/ThemeToggle.tsx';
 
 const navItems = [
   { label: 'About', href: '#about' },
@@ -30,6 +31,7 @@ const resumePath = '/Rafael_Abreu_Resume.pdf';
     </div>
 
     <div class="hidden md:flex items-center gap-3">
+      <ThemeToggle client:load />
       <a
         href={resumePath}
         target="_blank"

--- a/frontend/src/components/ProjectCard.astro
+++ b/frontend/src/components/ProjectCard.astro
@@ -15,7 +15,7 @@ const { title, description, tags, github, demo } = Astro.props;
   <p class="text-text-muted text-sm mt-2 line-clamp-2">{description}</p>
   <div class="mt-3 flex flex-wrap gap-1.5">
     {tags.slice(0, 3).map((tag) => (
-      <span class="font-mono text-[10px] px-2 py-0.5 rounded-tag bg-white/5 text-text-secondary">
+      <span class="font-mono text-[10px] px-2 py-0.5 rounded-tag bg-surface text-text-secondary">
         {tag}
       </span>
     ))}

--- a/frontend/src/components/Skills.astro
+++ b/frontend/src/components/Skills.astro
@@ -42,7 +42,7 @@ const categories = [
           </div>
           <div class="flex flex-wrap gap-2">
             {cat.skills.map((skill) => (
-              <span class="font-mono text-xs text-text-secondary bg-white/5 px-2.5 py-1 rounded-tag">
+              <span class="font-mono text-xs text-text-secondary bg-surface px-2.5 py-1 rounded-tag">
                 {skill}
               </span>
             ))}

--- a/frontend/src/islands/ChatWidget.tsx
+++ b/frontend/src/islands/ChatWidget.tsx
@@ -79,15 +79,15 @@ export default function ChatWidget() {
       </button>
 
       {isOpen && (
-        <div className="fixed bottom-20 right-5 z-50 w-[360px] max-h-[500px] bg-[#0a0a0f] border border-white/10 rounded-xl shadow-2xl flex flex-col overflow-hidden">
-          <div className="px-4 py-3 border-b border-white/10">
-            <div className="text-white text-sm font-bold">Ask Rafael's AI</div>
-            <div className="text-gray-500 text-xs mt-0.5">Ask about experience, projects, or skills</div>
+        <div className="fixed bottom-20 right-5 z-50 w-[360px] max-h-[500px] bg-base border border-surface-border rounded-xl shadow-2xl flex flex-col overflow-hidden">
+          <div className="px-4 py-3 border-b border-surface-border">
+            <div className="text-text-primary text-sm font-bold">Ask Rafael's AI</div>
+            <div className="text-text-muted text-xs mt-0.5">Ask about experience, projects, or skills</div>
           </div>
 
           <div className="flex-1 overflow-y-auto p-4 space-y-3 min-h-[200px] max-h-[340px]">
             {messages.length === 0 && (
-              <div className="text-gray-500 text-sm">
+              <div className="text-text-muted text-sm">
                 Hey! I'm Rafael's AI assistant. Ask me about his experience, projects, or tech stack.
               </div>
             )}
@@ -97,8 +97,8 @@ export default function ChatWidget() {
                 <div
                   className={`max-w-[85%] px-3 py-2 rounded-lg text-sm ${
                     msg.role === 'user'
-                      ? 'bg-[#6366f1] text-white'
-                      : 'bg-white/5 text-gray-300'
+                      ? 'bg-accent-indigo text-white'
+                      : 'bg-surface text-text-secondary'
                   }`}
                 >
                   {msg.content}
@@ -108,7 +108,7 @@ export default function ChatWidget() {
 
             {isLoading && (
               <div className="flex justify-start">
-                <div className="bg-white/5 text-gray-400 px-3 py-2 rounded-lg text-sm">
+                <div className="bg-surface text-text-muted px-3 py-2 rounded-lg text-sm">
                   Thinking...
                 </div>
               </div>
@@ -126,20 +126,20 @@ export default function ChatWidget() {
             <div ref={messagesEndRef} />
           </div>
 
-          <form onSubmit={sendMessage} className="p-3 border-t border-white/10 flex gap-2">
+          <form onSubmit={sendMessage} className="p-3 border-t border-surface-border flex gap-2">
             <input
               ref={inputRef}
               type="text"
               value={input}
               onChange={(e) => setInput(e.target.value)}
               placeholder="Ask something..."
-              className="flex-1 bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-500 outline-none focus:border-[#6366f1]/50"
+              className="flex-1 bg-surface border border-surface-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder-text-muted outline-none focus:border-accent-indigo/50"
               disabled={isLoading}
             />
             <button
               type="submit"
               disabled={isLoading || !input.trim()}
-              className="px-3 py-2 bg-[#6366f1] rounded-lg text-white text-sm disabled:opacity-40 hover:bg-[#6366f1]/90 transition-colors"
+              className="px-3 py-2 bg-accent-indigo rounded-lg text-white text-sm disabled:opacity-40 hover:bg-accent-indigo/90 transition-colors"
             >
               →
             </button>

--- a/frontend/src/islands/ChatWidget.tsx
+++ b/frontend/src/islands/ChatWidget.tsx
@@ -72,7 +72,7 @@ export default function ChatWidget() {
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="fixed bottom-5 right-5 z-50 w-[52px] h-[52px] rounded-[14px] flex items-center justify-center text-white text-xl shadow-lg transition-transform hover:scale-105"
-        style={{ background: 'linear-gradient(135deg, #6366f1, #8b5cf6)' }}
+        style={{ background: 'linear-gradient(135deg, var(--color-accent-indigo), var(--color-accent-purple))' }}
         aria-label={isOpen ? 'Close chat' : 'Open chat'}
       >
         {isOpen ? '✕' : '💬'}

--- a/frontend/src/islands/MobileNav.tsx
+++ b/frontend/src/islands/MobileNav.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import ThemeToggle from './ThemeToggle';
 
 interface NavItem {
   label: string;
@@ -21,25 +22,28 @@ export default function MobileNav({ navItems, resumePath }: Props) {
         aria-label={isOpen ? 'Close menu' : 'Open menu'}
       >
         <span
-          className={`block w-5 h-0.5 bg-white transition-all duration-300 ${
+          className={`block w-5 h-0.5 bg-text-primary transition-all duration-300 ${
             isOpen ? 'rotate-45 translate-y-1' : ''
           }`}
         />
         <span
-          className={`block w-5 h-0.5 bg-white transition-all duration-300 ${
+          className={`block w-5 h-0.5 bg-text-primary transition-all duration-300 ${
             isOpen ? '-rotate-45 -translate-y-1' : ''
           }`}
         />
       </button>
 
       {isOpen && (
-        <div className="fixed inset-0 z-40 bg-[#050508] flex flex-col items-center justify-center gap-8">
+        <div className="fixed inset-0 z-40 bg-base flex flex-col items-center justify-center gap-8">
+          <div className="absolute top-5 right-14">
+            <ThemeToggle />
+          </div>
           {navItems.map((item) => (
             <a
               key={item.label}
               href={item.href}
               onClick={() => setIsOpen(false)}
-              className="text-white text-2xl font-bold hover:text-[#6366f1] transition-colors"
+              className="text-text-primary text-2xl font-bold hover:text-accent-indigo transition-colors"
               style={{ letterSpacing: '-0.06em' }}
             >
               {item.label}
@@ -50,14 +54,14 @@ export default function MobileNav({ navItems, resumePath }: Props) {
               href={resumePath}
               target="_blank"
               rel="noopener noreferrer"
-              className="px-6 py-2 border border-[#6366f1]/40 rounded-lg text-[#6366f1] text-sm"
+              className="px-6 py-2 border border-accent-indigo/40 rounded-lg text-accent-indigo text-sm"
             >
               RESUME
             </a>
             <a
               href="#contact"
               onClick={() => setIsOpen(false)}
-              className="px-6 py-2 bg-[#6366f1] rounded-lg text-white text-sm"
+              className="px-6 py-2 bg-accent-indigo rounded-lg text-white text-sm"
             >
               LET'S TALK
             </a>

--- a/frontend/src/islands/MobileNav.tsx
+++ b/frontend/src/islands/MobileNav.tsx
@@ -59,7 +59,7 @@ export default function MobileNav({ navItems, resumePath }: Props) {
               RESUME
             </a>
             <a
-              href="#contact"
+              href="/#contact"
               onClick={() => setIsOpen(false)}
               className="px-6 py-2 bg-accent-indigo rounded-lg text-white text-sm"
             >

--- a/frontend/src/islands/ParticleHero.tsx
+++ b/frontend/src/islands/ParticleHero.tsx
@@ -101,18 +101,31 @@ interface Particle {
   baseSize: number;
 }
 
-const PALETTE = [
+const DARK_PALETTE = [
   [0.389, 0.4, 0.945],   // #6366f1 indigo
   [0.545, 0.361, 0.965],  // #8b5cf6 purple
   [0.925, 0.286, 0.600],  // #ec4899 pink
 ] as const;
 
-function initParticles(width: number, height: number, isMobile: boolean): Particle[] {
+const LIGHT_PALETTE = [
+  [0.310, 0.275, 0.898],  // #4F46E5 indigo (deeper)
+  [0.486, 0.227, 0.929],  // #7C3AED purple (deeper)
+  [0.859, 0.153, 0.467],  // #DB2777 pink (deeper)
+] as const;
+
+const DARK_LINE_COLOR: [number, number, number] = [0.389, 0.4, 0.945];
+const LIGHT_LINE_COLOR: [number, number, number] = [0.310, 0.275, 0.898];
+
+function isLightTheme(): boolean {
+  return document.documentElement.dataset.theme === 'light';
+}
+
+function initParticles(width: number, height: number, isMobile: boolean, palette: typeof DARK_PALETTE): Particle[] {
   const count = Math.max(60, Math.min(120, Math.floor(width / 15)));
   const speedMultiplier = isMobile ? 1.5 : 1.0;
   const particles: Particle[] = [];
   for (let i = 0; i < count; i++) {
-    const color = PALETTE[Math.floor(Math.random() * PALETTE.length)];
+    const color = palette[Math.floor(Math.random() * palette.length)];
     particles.push({
       x: Math.random() * width,
       y: Math.random() * height,
@@ -179,6 +192,7 @@ export default function ParticleHero() {
     let mouseY = -1000;
     let animId = 0;
     let paused = false;
+    let currentLight = isLightTheme();
 
     function resize() {
       if (!canvas || !gl) return;
@@ -188,7 +202,8 @@ export default function ParticleHero() {
       canvas.width = w;
       canvas.height = h;
       gl.viewport(0, 0, w, h);
-      particles = initParticles(w, h, isMobile);
+      currentLight = isLightTheme();
+      particles = initParticles(w, h, isMobile, currentLight ? LIGHT_PALETTE : DARK_PALETTE);
     }
 
     resize();
@@ -326,14 +341,19 @@ export default function ParticleHero() {
       gl.clearColor(0, 0, 0, 0);
       gl.clear(gl.COLOR_BUFFER_BIT);
       gl.enable(gl.BLEND);
-      gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+      if (currentLight) {
+        gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+      } else {
+        gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+      }
       gl.disable(gl.DEPTH_TEST);
 
       // Draw lines
       if (linePositions.length > 0) {
         gl.useProgram(lineProg);
         gl.uniform2f(lLoc.resolution, w, h);
-        gl.uniform3f(lLoc.color, 0.389, 0.4, 0.945); // indigo for lines
+        const lineColor = currentLight ? LIGHT_LINE_COLOR : DARK_LINE_COLOR;
+        gl.uniform3f(lLoc.color, lineColor[0], lineColor[1], lineColor[2]);
 
         gl.bindBuffer(gl.ARRAY_BUFFER, linePosBuf);
         gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(linePositions), gl.DYNAMIC_DRAW);
@@ -402,6 +422,25 @@ export default function ParticleHero() {
     window.addEventListener('scroll', onScroll, { passive: true });
     document.addEventListener('visibilitychange', onVisibility);
 
+    // Listen for theme changes
+    const themeObserver = new MutationObserver(() => {
+      const nowLight = isLightTheme();
+      if (nowLight !== currentLight) {
+        currentLight = nowLight;
+        const palette = currentLight ? LIGHT_PALETTE : DARK_PALETTE;
+        for (let i = 0; i < particles.length; i++) {
+          const color = palette[Math.floor(Math.random() * palette.length)];
+          particles[i].r = color[0];
+          particles[i].g = color[1];
+          particles[i].b = color[2];
+        }
+      }
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+
     // Start
     if (reducedMotion) {
       frame(); // Single static render
@@ -418,6 +457,7 @@ export default function ParticleHero() {
       canvas.removeEventListener('webglcontextlost', onContextLost);
       window.removeEventListener('scroll', onScroll);
       document.removeEventListener('visibilitychange', onVisibility);
+      themeObserver.disconnect();
       // Clean up WebGL resources
       gl.deleteBuffer(particlePosBuf);
       gl.deleteBuffer(particleSizeBuf);

--- a/frontend/src/islands/ThemeToggle.tsx
+++ b/frontend/src/islands/ThemeToggle.tsx
@@ -1,0 +1,67 @@
+import { useState, useEffect } from 'react';
+
+function getInitialTheme(): string {
+  if (typeof document !== 'undefined') {
+    return document.documentElement.dataset.theme || 'dark';
+  }
+  return 'dark';
+}
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState(getInitialTheme);
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      const current = document.documentElement.dataset.theme || 'dark';
+      setTheme(current);
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  function toggle() {
+    const next = theme === 'dark' ? 'light' : 'dark';
+
+    document.documentElement.classList.add('theme-transitioning');
+    document.documentElement.dataset.theme = next;
+    localStorage.setItem('theme', next);
+
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (meta) meta.setAttribute('content', next === 'light' ? '#F8F7F4' : '#050508');
+
+    setTimeout(() => {
+      document.documentElement.classList.remove('theme-transitioning');
+    }, 200);
+  }
+
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      onClick={toggle}
+      className="w-8 h-8 rounded-btn border border-surface-border flex items-center justify-center text-text-muted hover:text-accent-indigo hover:border-accent-indigo/40 transition-colors duration-200"
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+    >
+      {isDark ? (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="5" />
+          <line x1="12" y1="1" x2="12" y2="3" />
+          <line x1="12" y1="21" x2="12" y2="23" />
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+          <line x1="1" y1="12" x2="3" y2="12" />
+          <line x1="21" y1="12" x2="23" y2="12" />
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+        </svg>
+      ) : (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/frontend/src/layouts/BaseLayout.astro
+++ b/frontend/src/layouts/BaseLayout.astro
@@ -21,6 +21,17 @@ const {
     <meta name="theme-color" content="#050508" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <title>{title}</title>
+    <script is:inline>
+      (function() {
+        var theme = localStorage.getItem('theme');
+        if (!theme) {
+          theme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+        }
+        document.documentElement.dataset.theme = theme;
+        var meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) meta.setAttribute('content', theme === 'light' ? '#F8F7F4' : '#050508');
+      })();
+    </script>
   </head>
   <body>
     <slot />

--- a/frontend/src/layouts/ProjectLayout.astro
+++ b/frontend/src/layouts/ProjectLayout.astro
@@ -90,7 +90,7 @@ const tagColorClasses = [
 
     <style>
       .prose-custom :global(h2) {
-        color: #ffffff;
+        color: var(--color-text-primary);
         font-size: 1.5rem;
         font-weight: 800;
         letter-spacing: -0.04em;
@@ -98,12 +98,12 @@ const tagColorClasses = [
         margin-bottom: 1rem;
       }
       .prose-custom :global(p) {
-        color: #a0a0b0;
+        color: var(--color-text-secondary);
         line-height: 1.7;
         margin-bottom: 1rem;
       }
       .prose-custom :global(ul) {
-        color: #a0a0b0;
+        color: var(--color-text-secondary);
         list-style: none;
         padding-left: 0;
       }
@@ -116,15 +116,15 @@ const tagColorClasses = [
         content: '→';
         position: absolute;
         left: 0;
-        color: #6366f1;
+        color: var(--color-accent-indigo);
       }
       .prose-custom :global(strong) {
-        color: #ffffff;
+        color: var(--color-text-primary);
         font-weight: 600;
       }
       .prose-custom :global(code) {
         font-family: 'Courier New', monospace;
-        background: rgba(255,255,255,0.05);
+        background: var(--color-surface);
         padding: 0.15rem 0.4rem;
         border-radius: 4px;
         font-size: 0.875rem;

--- a/frontend/src/layouts/ProjectLayout.astro
+++ b/frontend/src/layouts/ProjectLayout.astro
@@ -32,6 +32,17 @@ const tagColorClasses = [
     <meta name="theme-color" content="#050508" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <title>{title} | Rafael Abreu</title>
+    <script is:inline>
+      (function() {
+        var theme = localStorage.getItem('theme');
+        if (!theme) {
+          theme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+        }
+        document.documentElement.dataset.theme = theme;
+        var meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) meta.setAttribute('content', theme === 'light' ? '#F8F7F4' : '#050508');
+      })();
+    </script>
   </head>
   <body class="bg-base text-text-secondary">
     <Nav />

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -19,6 +19,31 @@
   --radius-btn: 8px;
 }
 
+html[data-theme="light"] {
+  --color-base: #F8F7F4;
+  --color-surface: #FFFFFF;
+  --color-surface-border: rgba(0, 0, 0, 0.06);
+  --color-text-primary: #111111;
+  --color-text-secondary: #555555;
+  --color-text-muted: #999999;
+  --color-accent-indigo: #4F46E5;
+  --color-accent-purple: #7C3AED;
+  --color-accent-pink: #DB2777;
+  --color-accent-indigo-light: #4F46E5;
+  --color-accent-purple-light: #7C3AED;
+  --color-accent-pink-light: #DB2777;
+}
+
+html.theme-transitioning * {
+  transition: background-color 200ms ease, color 200ms ease, border-color 200ms ease !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.theme-transitioning * {
+    transition: none !important;
+  }
+}
+
 @layer base {
   body {
     @apply bg-base text-text-secondary antialiased;
@@ -52,6 +77,10 @@
 @utility gradient-divider {
   height: 1px;
   background: linear-gradient(90deg, transparent, rgba(99, 102, 241, 0.3), rgba(139, 92, 246, 0.2), transparent);
+}
+
+html[data-theme="light"] .gradient-divider {
+  background: linear-gradient(90deg, transparent, rgba(79, 70, 229, 0.4), rgba(124, 58, 237, 0.3), transparent);
 }
 
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -19,6 +19,22 @@
   --radius-btn: 8px;
 }
 
+html[data-theme="dark"],
+html:not([data-theme]) {
+  --color-base: #050508;
+  --color-surface: rgba(255, 255, 255, 0.03);
+  --color-surface-border: rgba(255, 255, 255, 0.06);
+  --color-text-primary: #ffffff;
+  --color-text-secondary: #a0a0b0;
+  --color-text-muted: #666666;
+  --color-accent-indigo: #6366f1;
+  --color-accent-purple: #8b5cf6;
+  --color-accent-pink: #ec4899;
+  --color-accent-indigo-light: #a5b4fc;
+  --color-accent-purple-light: #c4b5fd;
+  --color-accent-pink-light: #f9a8d4;
+}
+
 html[data-theme="light"] {
   --color-base: #F8F7F4;
   --color-surface: #FFFFFF;


### PR DESCRIPTION
## Summary

- Add dark/light theme toggle with hybrid light palette (warm base #F8F7F4, crisp white surfaces)
- ThemeToggle React island in nav bar (desktop + mobile) with SVG sun/moon icons
- Flash prevention via inline head script (localStorage → prefers-color-scheme → dark default)
- Smooth 200ms CSS transition on toggle, respects prefers-reduced-motion
- ParticleHero WebGL adapts colors and blending mode per theme
- Replace ~20 hardcoded color values across 7 components with theme tokens
- Fix nav anchor links to work from non-homepage routes (/playground, /project/*)
- Fix .gitignore `src/` → `/src/` to unblock Tailwind v4 source scanning

## Files changed (12)

| File | Change |
|------|--------|
| `global.css` | Light palette tokens, dark defaults, transition rule, gradient-divider override |
| `ThemeToggle.tsx` | New island — toggle with sun/moon SVG, localStorage, MutationObserver |
| `Nav.astro` | Add toggle, fix anchor hrefs to absolute paths |
| `MobileNav.tsx` | Add toggle, fix hardcoded colors, fix anchor hrefs |
| `BaseLayout.astro` | Flash prevention head script |
| `ProjectLayout.astro` | Flash prevention head script, prose styles → CSS vars |
| `ParticleHero.tsx` | Dual palettes, blending mode switch, theme MutationObserver |
| `ChatWidget.tsx` | All hardcoded colors → theme tokens |
| `Hero.astro` | `border-white/15` → `border-surface-border` |
| `Skills.astro` | `bg-white/5` → `bg-surface` |
| `ProjectCard.astro` | `bg-white/5` → `bg-surface` |
| `.gitignore` | `src/` → `/src/` (root-relative, fixes Tailwind source scanning) |

## Test plan

- [ ] Dark mode: page loads styled, particles glow, all sections correct
- [ ] Light mode: toggle → warm white bg, dark text, solid particles
- [ ] Persistence: refresh preserves theme, no flash
- [ ] Mobile: hamburger overlay shows toggle, colors correct
- [ ] Chat widget: panel matches theme in both modes
- [ ] Playground: game board correct, nav links navigate to homepage sections
- [ ] Project detail: prose content readable in both themes
- [ ] Accessibility: prefers-reduced-motion skips transition, prefers-color-scheme respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)