### PR TITLE
feat: add privacy-respecting analytics (P5)

### DIFF
--- a/docs/superpowers/specs/2026-04-11-privacy-analytics-design.md
+++ b/docs/superpowers/specs/2026-04-11-privacy-analytics-design.md
@@ -1,0 +1,50 @@
+# P5: Privacy-Respecting Analytics — Design Spec
+
+## Overview
+
+Add Umami Cloud analytics to the portfolio to track visitor behavior without cookies or personal data. Zero cost (free tier), zero maintenance (hosted), GDPR compliant.
+
+## Script Tag
+
+```html
+<script is:inline defer src="https://cloud.umami.is/script.js" data-website-id="f17cb708-288b-471b-989f-d7115bfcbec4"></script>
+```
+
+Added to both `BaseLayout.astro` and `ProjectLayout.astro` `<head>` sections. Uses `is:inline` to prevent Astro bundling. Wrapped in `import.meta.env.PROD` check to skip in dev.
+
+## Custom Event Tracking
+
+Umami supports custom events via `umami.track('event-name')` calls. Track these interactions:
+
+- **chat-opened** — fired when user opens the ChatWidget (clicks the FAB button to open, not close)
+- **game-started** — fired on the first move in a GameBoard session (not on subsequent moves or replays)
+
+Events use the global `umami.track()` function which is available after the script loads. Guard calls with `typeof umami !== 'undefined'` to prevent errors in dev or if the script fails to load.
+
+## Environment Awareness
+
+Only load the script in production builds. In Astro, use:
+
+```astro
+{import.meta.env.PROD && (
+  <script is:inline defer src="..." data-website-id="..."></script>
+)}
+```
+
+This prevents localhost traffic from polluting analytics data.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/layouts/BaseLayout.astro` | Add Umami script tag (prod only) |
+| `src/layouts/ProjectLayout.astro` | Add Umami script tag (prod only) |
+| `src/islands/ChatWidget.tsx` | Add `umami.track('chat-opened')` on open |
+| `src/islands/GameBoard.tsx` | Add `umami.track('game-started')` on first move |
+
+## Out of Scope
+
+- Self-hosted Umami
+- Custom dashboard embedding in the portfolio
+- Server-side analytics
+- Tracking project card clicks (Umami auto-tracks page navigations)

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="astro/client" />
+
+declare const umami:
+  | {
+      track: (event: string, data?: Record<string, unknown>) => void;
+    }
+  | undefined;

--- a/frontend/src/islands/ChatWidget.tsx
+++ b/frontend/src/islands/ChatWidget.tsx
@@ -70,7 +70,10 @@ export default function ChatWidget() {
   return (
     <>
       <button
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => {
+          if (!isOpen && typeof umami !== 'undefined') umami.track('chat-opened');
+          setIsOpen(!isOpen);
+        }}
         className="fixed bottom-5 right-5 z-50 w-[52px] h-[52px] rounded-[14px] flex items-center justify-center text-white text-xl shadow-lg transition-transform hover:scale-105"
         style={{ background: 'linear-gradient(135deg, var(--color-accent-indigo), var(--color-accent-purple))' }}
         aria-label={isOpen ? 'Close chat' : 'Open chat'}

--- a/frontend/src/islands/GameBoard.tsx
+++ b/frontend/src/islands/GameBoard.tsx
@@ -40,6 +40,7 @@ export default function GameBoard() {
     }
 
     setError(null);
+    if (status === 'waiting' && typeof umami !== 'undefined') umami.track('game-started');
     const prevBoard = [...board];
     const newBoard = [...board];
     newBoard[index] = 'X';

--- a/frontend/src/layouts/BaseLayout.astro
+++ b/frontend/src/layouts/BaseLayout.astro
@@ -32,6 +32,7 @@ const {
         if (meta) meta.setAttribute('content', theme === 'light' ? '#F8F7F4' : '#050508');
       })();
     </script>
+    {import.meta.env.PROD && <script is:inline defer src="https://cloud.umami.is/script.js" data-website-id="f17cb708-288b-471b-989f-d7115bfcbec4"></script>}
   </head>
   <body>
     <slot />

--- a/frontend/src/layouts/BaseLayout.astro
+++ b/frontend/src/layouts/BaseLayout.astro
@@ -32,7 +32,7 @@ const {
         if (meta) meta.setAttribute('content', theme === 'light' ? '#F8F7F4' : '#050508');
       })();
     </script>
-    {import.meta.env.PROD && <script is:inline defer src="https://cloud.umami.is/script.js" data-website-id="f17cb708-288b-471b-989f-d7115bfcbec4"></script>}
+    {import.meta.env.PROD && <script is:inline async src="https://cloud.umami.is/script.js" data-website-id="f17cb708-288b-471b-989f-d7115bfcbec4"></script>}
   </head>
   <body>
     <slot />

--- a/frontend/src/layouts/ProjectLayout.astro
+++ b/frontend/src/layouts/ProjectLayout.astro
@@ -43,7 +43,7 @@ const tagColorClasses = [
         if (meta) meta.setAttribute('content', theme === 'light' ? '#F8F7F4' : '#050508');
       })();
     </script>
-    {import.meta.env.PROD && <script is:inline defer src="https://cloud.umami.is/script.js" data-website-id="f17cb708-288b-471b-989f-d7115bfcbec4"></script>}
+    {import.meta.env.PROD && <script is:inline async src="https://cloud.umami.is/script.js" data-website-id="f17cb708-288b-471b-989f-d7115bfcbec4"></script>}
   </head>
   <body class="bg-base text-text-secondary">
     <Nav />

--- a/frontend/src/layouts/ProjectLayout.astro
+++ b/frontend/src/layouts/ProjectLayout.astro
@@ -43,6 +43,7 @@ const tagColorClasses = [
         if (meta) meta.setAttribute('content', theme === 'light' ? '#F8F7F4' : '#050508');
       })();
     </script>
+    {import.meta.env.PROD && <script is:inline defer src="https://cloud.umami.is/script.js" data-website-id="f17cb708-288b-471b-989f-d7115bfcbec4"></script>}
   </head>
   <body class="bg-base text-text-secondary">
     <Nav />


### PR DESCRIPTION
## Summary

- Add Umami Cloud analytics (free tier, no cookies, GDPR compliant)
- Script tag in both layouts, production-only via `import.meta.env.PROD`
- Custom events: `chat-opened` (ChatWidget), `game-started` (GameBoard)

## Files changed (4)

| File | Change |
|------|--------|
| `BaseLayout.astro` | Add Umami script tag (prod only) |
| `ProjectLayout.astro` | Add Umami script tag (prod only) |
| `ChatWidget.tsx` | Track `chat-opened` event |
| `GameBoard.tsx` | Track `game-started` event on first move |

## Test plan

- [ ] Dev server: no Umami script in page source (prod-only check)
- [ ] Production build: Umami script present in HTML output
- [ ] Open chat widget → `chat-opened` event fires in Umami dashboard
- [ ] Play first move in game → `game-started` event fires
- [ ] Subsequent moves do NOT re-fire `game-started`
- [ ] No console errors from `umami.track()` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)