### PR TITLE
fix: restore bare gitignore patterns for tool/IDE dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,9 @@
 .DS_Store
 Thumbs.db
 
-# IDE
-/.vscode/
-/.idea/
+# IDE — bare so they match at any depth (e.g. frontend/.vscode/)
+.vscode/
+.idea/
 *.swp
 *.swo
 
@@ -26,19 +26,13 @@ Thumbs.db
 /api/tmp/
 /api/server
 
-# Astro
-/.astro/
+# Tool dirs — bare so they match at any depth (e.g. frontend/.astro/)
+.astro/
+.claude/
+.superpowers/
+.netlify
 
-# Claude Code (local config)
-/.claude/
-
-# Superpowers (brainstorm sessions)
-/.superpowers/
-
-# Legacy CRA (removed in V1 cleanup — root-relative to avoid blocking frontend/src/)
+# Legacy CRA (root-relative to avoid blocking Tailwind v4 scanning of frontend/src/)
 /build/
 /src/
 /public/
-
-# Local Netlify folder
-/.netlify

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Each feature follows: design spec → implementation plan → feature branch →
 - **ALL work happens on feature branches** (`feature/<name>`, `fix/<name>`). Merge to `main` only via PR.
 - **No "safe" exceptions.** Docs, dependency patches, config changes — everything triggers CI/CD. There is no safe push to main.
 - **Verify locally before any merge.** Run `npm run build` (frontend) and `go test ./...` (API) and visually confirm in the browser.
-- **`.gitignore` patterns must be root-relative** (`/src/` not `src/`) to avoid blocking Tailwind v4's source scanning of `frontend/src/`. Bare patterns match recursively and will silently break utility class generation.
+- **`.gitignore` pattern rules:** Patterns that could shadow real source directories (`src/`, `build/`, `public/`, `node_modules/`) **must be root-relative** (`/src/` not `src/`) to avoid blocking Tailwind v4's scanning of `frontend/src/`. Tool/IDE directories that legitimately appear at any depth (`.vscode/`, `.astro/`, `.netlify`, `.claude/`) **must stay bare** so they match recursively (e.g. `frontend/.vscode/`).
 
 ## Branching
 


### PR DESCRIPTION
## Summary
- **Fixes regression from #23**: root-relative patterns (`/.vscode/`, `/.netlify`) only match at repo root, breaking coverage for nested dirs like `frontend/.vscode/`
- **Restores bare patterns** for tool/IDE dirs (`.vscode/`, `.idea/`, `.astro/`, `.claude/`, `.superpowers/`, `.netlify`) so they match recursively at any depth
- **Clarifies the gitignore rule in CLAUDE.md** to distinguish root-relative (source dirs) from bare (tool/IDE dirs)

## Test plan
- [x] `npm run build` — 10 pages built
- [x] `go test ./...` — all pass
- [x] `git status` confirms `frontend/.vscode/` and `frontend/.netlify/` are ignored again

🤖 Generated with [Claude Code](https://claude.com/claude-code)