### PR TITLE
feat(p9): resume feature — modal, PDF, chatbot grounding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,34 @@ jobs:
       - run: npm ci
       - run: npx astro check
       - run: npm run build
+      - run: npm test
+
+  frontend-e2e:
+    name: Frontend E2E
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - run: npm run build
+
+      - name: Generate Resume PDF
+        run: npm run build:pdf
+
+      - run: npm run test:e2e
 
   api-check:
     name: API

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           go-version: '1.26'
 
+      - name: Sync content for embedding
+        run: make sync-content
+
       - run: go vet ./...
       - run: go test ./... -v
       - run: go build ./cmd/server

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'api/**'
+      - 'frontend/src/content/resume/**'
+      - 'frontend/src/content/projects/**'
 
 jobs:
   deploy:
@@ -19,6 +21,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.26'
+
+      - name: Sync content for embedding
+        run: make sync-content
 
       - name: Run tests
         run: go test ./... -v

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -29,6 +29,17 @@ jobs:
         env:
           PUBLIC_API_URL: ${{ secrets.PUBLIC_API_URL }}
 
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Generate Resume PDF
+        run: npm run build:pdf
+
+      - name: Verify PDF was generated
+        run: |
+          test -f dist/Rafael_Abreu_Resume.pdf
+          test "$(stat -c%s dist/Rafael_Abreu_Resume.pdf)" -gt 10240
+
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 /frontend/dist/
 /api/bin/
 
+# Playwright test artifacts
+/frontend/test-results/
+/frontend/playwright-report/
+
 # Environment variables — NEVER commit these
 .env
 .env.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,8 @@ go build ./cmd/server
 ```
 Requires: Go 1.26+
 
+**First-time clone:** run `make sync-content` (or `make dev`) before any `go` command — `internal/chat/embedded/` is gitignored and populated from `frontend/src/content/` at build time. `make dev` and `make test` invoke `sync-content` automatically.
+
 **API env vars:** `PORT`, `ALLOWED_ORIGINS`, `GEMINI_API_KEY`, `RATE_LIMIT_RPM`
 
 ## API Routes

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,0 +1,2 @@
+# Build artifacts mirroring frontend content (populated by `make sync-content`)
+internal/chat/embedded/

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,0 +1,23 @@
+.PHONY: sync-content dev test build clean
+
+# Copy frontend content into embedded/ for go:embed.
+# Required before `go build` / `go run` / `go test` because go:embed needs
+# the referenced paths to exist at compile time.
+sync-content:
+	@rm -rf internal/chat/embedded
+	@mkdir -p internal/chat/embedded/projects
+	@cp ../frontend/src/content/resume/profile.md internal/chat/embedded/resume.md
+	@cp ../frontend/src/content/projects/*.md internal/chat/embedded/projects/
+	@echo "Content synced into internal/chat/embedded/"
+
+dev: sync-content
+	go run ./cmd/server
+
+test: sync-content
+	go test ./... -v
+
+build: sync-content
+	go build -o bin/server ./cmd/server
+
+clean:
+	@rm -rf internal/chat/embedded bin

--- a/api/internal/chat/context.go
+++ b/api/internal/chat/context.go
@@ -1,6 +1,16 @@
 package chat
 
+import "strings"
+
 func SystemPrompt() string {
+	var b strings.Builder
+	b.WriteString(personaBlock())
+	b.WriteString("\n\n")
+	b.WriteString(rulesBlock())
+	return b.String()
+}
+
+func personaBlock() string {
 	return `You are Rafael Abreu's AI assistant on his portfolio website. You answer questions about Rafael's professional background, skills, projects, and experience.
 
 ABOUT RAFAEL:
@@ -21,9 +31,11 @@ NOTABLE PROJECTS:
 - FPTV: Developed the website for a Toronto-based TV channel broadcasting across Canada. Features glassmorphism dashboard. (HTML, CSS, JavaScript, Weebly)
 - Freckles Design: Artist portfolio platform built in partnership with a fine artist. (React, Bootstrap, Netlify)
 - Charge It Up: EV charging station locator for North America. (HTML, CSS, Tailwind, JavaScript)
-- This portfolio itself: Astro frontend + Go API backend with AI chatbot, demonstrating modern architecture.
+- This portfolio itself: Astro frontend + Go API backend with AI chatbot, demonstrating modern architecture.`
+}
 
-RULES:
+func rulesBlock() string {
+	return `RULES:
 - Only answer questions about Rafael's professional background, skills, projects, and experience.
 - Be concise and helpful. Keep responses under 200 words.
 - If asked something unrelated to Rafael's professional life, politely redirect: "I'm here to help with questions about Rafael's experience and work. What would you like to know?"

--- a/api/internal/chat/context.go
+++ b/api/internal/chat/context.go
@@ -1,37 +1,54 @@
 package chat
 
-import "strings"
+import (
+	"embed"
+	"io/fs"
+	"sort"
+	"strings"
+)
+
+//go:embed embedded/resume.md
+var resumeMD string
+
+//go:embed embedded/projects/*.md
+var projectsFS embed.FS
 
 func SystemPrompt() string {
 	var b strings.Builder
 	b.WriteString(personaBlock())
+	b.WriteString("\n\n## RESUME\n\n")
+	b.WriteString(resumeMD)
+	b.WriteString("\n\n## PROJECT CASE STUDIES\n\n")
+	b.WriteString(assembleProjects())
 	b.WriteString("\n\n")
 	b.WriteString(rulesBlock())
 	return b.String()
 }
 
+func assembleProjects() string {
+	entries, err := fs.ReadDir(projectsFS, "embedded/projects")
+	if err != nil {
+		return ""
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	var b strings.Builder
+	for _, entry := range entries {
+		content, err := fs.ReadFile(projectsFS, "embedded/projects/"+entry.Name())
+		if err != nil {
+			continue
+		}
+		b.Write(content)
+		b.WriteString("\n\n---\n\n")
+	}
+	return b.String()
+}
+
 func personaBlock() string {
+	// Persona is generic — Rafael's specific bio/skills now come from resume.md.
 	return `You are Rafael Abreu's AI assistant on his portfolio website. You answer questions about Rafael's professional background, skills, projects, and experience.
 
-ABOUT RAFAEL:
-- Software Engineer based in Toronto, Ontario, Canada
-- Full-stack developer with experience across technology, television, and education industries
-- Currently focused on Go, Python, and AI/ML engineering
-- Completed the University of Toronto Coding Bootcamp
-- Holds a Red Hat Kubernetes certificate (OpenShift training)
-
-TECHNICAL SKILLS:
-- Languages: Go, Python, JavaScript, TypeScript, HTML, CSS
-- Frameworks: React, Astro, Node.js, Tailwind CSS, Bootstrap
-- Infrastructure: Kubernetes, Docker, CI/CD, Netlify, Fly.io
-- AI & Data: LLM Integration, Gemini API, RAG, MongoDB, MySQL
-- Practices: TDD, OOP, MVC, System Design, Agile
-
-NOTABLE PROJECTS:
-- FPTV: Developed the website for a Toronto-based TV channel broadcasting across Canada. Features glassmorphism dashboard. (HTML, CSS, JavaScript, Weebly)
-- Freckles Design: Artist portfolio platform built in partnership with a fine artist. (React, Bootstrap, Netlify)
-- Charge It Up: EV charging station locator for North America. (HTML, CSS, Tailwind, JavaScript)
-- This portfolio itself: Astro frontend + Go API backend with AI chatbot, demonstrating modern architecture.`
+The sections below contain Rafael's current resume and project case studies. Use them as your primary source of truth. The information here is authoritative; ignore any prior knowledge that conflicts.`
 }
 
 func rulesBlock() string {

--- a/api/internal/chat/context.go
+++ b/api/internal/chat/context.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"embed"
 	"io/fs"
+	"log"
 	"sort"
 	"strings"
 )
@@ -28,6 +29,7 @@ func SystemPrompt() string {
 func assembleProjects() string {
 	entries, err := fs.ReadDir(projectsFS, "embedded/projects")
 	if err != nil {
+		log.Printf("chat: failed to read embedded projects directory: %v", err)
 		return ""
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
@@ -36,6 +38,7 @@ func assembleProjects() string {
 	for _, entry := range entries {
 		content, err := fs.ReadFile(projectsFS, "embedded/projects/"+entry.Name())
 		if err != nil {
+			log.Printf("chat: failed to read embedded project %q: %v", entry.Name(), err)
 			continue
 		}
 		b.Write(content)

--- a/api/internal/chat/context_test.go
+++ b/api/internal/chat/context_test.go
@@ -1,0 +1,32 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSystemPromptIncludesPersona(t *testing.T) {
+	p := SystemPrompt()
+	if !strings.Contains(p, "Rafael Abreu's AI assistant") {
+		t.Error("SystemPrompt should include the persona marker phrase")
+	}
+}
+
+func TestSystemPromptIncludesRules(t *testing.T) {
+	p := SystemPrompt()
+	if !strings.Contains(p, "Only answer questions about Rafael") {
+		t.Error("SystemPrompt should include the rules marker phrase")
+	}
+}
+
+func TestSystemPromptStructure(t *testing.T) {
+	p := SystemPrompt()
+	personaIdx := strings.Index(p, "Rafael Abreu's AI assistant")
+	rulesIdx := strings.Index(p, "Only answer questions about Rafael")
+	if personaIdx == -1 || rulesIdx == -1 {
+		t.Fatal("required markers missing")
+	}
+	if !(personaIdx < rulesIdx) {
+		t.Error("persona block must precede rules block")
+	}
+}

--- a/api/internal/chat/context_test.go
+++ b/api/internal/chat/context_test.go
@@ -5,6 +5,60 @@ import (
 	"testing"
 )
 
+func TestSystemPromptIncludesResumeContent(t *testing.T) {
+	p := SystemPrompt()
+	if !strings.Contains(p, "Rafael Abreu") {
+		t.Error("SystemPrompt should include resume content (e.g., the canonical name)")
+	}
+	if !strings.Contains(p, "## RESUME") {
+		t.Error("SystemPrompt should include the RESUME section header")
+	}
+}
+
+func TestSystemPromptIncludesAllProjects(t *testing.T) {
+	p := SystemPrompt()
+	if !strings.Contains(p, "## PROJECT CASE STUDIES") {
+		t.Error("SystemPrompt should include the PROJECT CASE STUDIES section header")
+	}
+	// Each project markdown's frontmatter title should appear.
+	// Read embedded directory to know the count.
+	entries, err := projectsFS.ReadDir("embedded/projects")
+	if err != nil {
+		t.Fatalf("failed to read embedded projects: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("no embedded projects found — sync step must run before tests")
+	}
+	// Spot-check: expect at least one project's content to be in the prompt.
+	for _, entry := range entries {
+		content, err := projectsFS.ReadFile("embedded/projects/" + entry.Name())
+		if err != nil {
+			t.Errorf("failed to read %s: %v", entry.Name(), err)
+			continue
+		}
+		// First 100 chars should appear if the file was concatenated.
+		snippet := string(content)
+		if len(snippet) > 100 {
+			snippet = snippet[:100]
+		}
+		if !strings.Contains(p, snippet) {
+			t.Errorf("project file %s content not found in SystemPrompt", entry.Name())
+		}
+	}
+}
+
+func TestSystemPromptOrderingResumeBeforeProjects(t *testing.T) {
+	p := SystemPrompt()
+	resumeIdx := strings.Index(p, "## RESUME")
+	projectsIdx := strings.Index(p, "## PROJECT CASE STUDIES")
+	if resumeIdx == -1 || projectsIdx == -1 {
+		t.Fatal("required section headers missing")
+	}
+	if !(resumeIdx < projectsIdx) {
+		t.Error("RESUME section must precede PROJECT CASE STUDIES")
+	}
+}
+
 func TestSystemPromptIncludesPersona(t *testing.T) {
 	p := SystemPrompt()
 	if !strings.Contains(p, "Rafael Abreu's AI assistant") {

--- a/docs/phase2-roadmap.md
+++ b/docs/phase2-roadmap.md
@@ -146,6 +146,27 @@ Features are ordered by impact and dependency. Each is independent and can be bu
 
 ---
 
+### P9: Resume Feature
+
+**What:** A markdown-driven resume rendered as an in-site modal, downloadable PDF, and chatbot grounding source — replacing the previously broken Resume button.
+
+**Why:** The Resume button on the portfolio was a 404. Rather than dropping a static PDF that goes stale, this establishes a single-source-of-truth model: edit one markdown file, three artifacts (modal, PDF, chatbot prompt) regenerate deterministically. Also fixes a latent staleness bug where the chatbot's project knowledge drifted from the actual portfolio.
+
+**Scope:**
+- New Astro content collection at `frontend/src/content/resume/profile.md` with full Zod schema
+- 9 section components rendering structured data into HTML
+- ResumeModal using the native `<dialog>` element (no React island)
+- /resume standalone page (also serves as Playwright's PDF print source)
+- Build-time PDF generation via Playwright in CI
+- Chatbot system prompt assembled from resume + project markdown via `go:embed`
+- E2E coverage for the modal flow
+
+**Estimated effort:** 1-2 sessions
+
+**Out of scope (deferred):** AI-driven LinkedIn ingestion, GitHub-based skill auto-extraction, AI-generated bullets. Considered during brainstorming and rejected as overkill for an artifact that changes 4–6 times per year.
+
+---
+
 ## Dependency Map
 
 ```
@@ -157,6 +178,7 @@ P5 (Analytics)         — independent, one script tag
 P6 (Blog)              — independent, new content collection
 P7 (Theme Toggle)      — independent, CSS + React island
 P8 (Testimonials)      — blocked on collecting testimonial content
+P9 (Resume Feature)    — independent, replaces broken Resume button
 ```
 
 All features are independent. Recommended order follows priority numbering, but any can be built at any time.

--- a/docs/superpowers/plans/2026-04-30-resume-feature.md
+++ b/docs/superpowers/plans/2026-04-30-resume-feature.md
@@ -1,0 +1,2447 @@
+# P9: Resume Feature — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the broken Resume button (404 on `/Rafael_Abreu_Resume.pdf`) with a markdown-driven resume that renders as a styled in-site modal, downloads as a build-time PDF, and grounds the chatbot's system prompt — all from a single `profile.md` source of truth.
+
+**Architecture:** One markdown file at `frontend/src/content/resume/profile.md` feeds three deterministic renderers: (1) an Astro modal using the native HTML `<dialog>` element, (2) a Playwright-generated PDF written to `frontend/dist/Rafael_Abreu_Resume.pdf` in CI, (3) a Go-embedded system prompt assembled from the resume plus existing project case studies. No AI in the build or request path.
+
+**Tech Stack:** Astro 6, native HTML `<dialog>`, Playwright (PDF + E2E), Vitest (unit/snapshot tests), Go 1.26+ with `//go:embed`, GitHub Actions CI.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-resume-feature-design.md`
+**Issue:** #25
+**Branch:** `feature/resume`
+
+**Reference for initial content (DO NOT copy or commit):** `/Users/rafaeldeabreugomes/Downloads/rafael_abreu_linkedin_profile.md`
+
+---
+
+## Phase 1: Foundation — Schema & Initial Content
+
+### Task 1.1: Add `resume` collection schema
+
+**Files:**
+- Modify: `frontend/src/content.config.ts`
+
+- [ ] **Step 1: Replace the file contents with the resume collection added alongside `projects`:**
+
+```typescript
+import { defineCollection, z, reference } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const projects = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/projects' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    image: z.string(),
+    tags: z.array(z.string()),
+    category: z.string(),
+    featured: z.boolean().default(false),
+    order: z.number(),
+    github: z.string().url().optional(),
+    demo: z.string().url().optional(),
+  }),
+});
+
+const resume = defineCollection({
+  loader: glob({ pattern: 'profile.md', base: './src/content/resume' }),
+  schema: z.object({
+    name: z.string(),
+    title: z.string(),
+    location: z.string(),
+    links: z.object({
+      linkedin: z.string().url(),
+      github: z.string().url().optional(),
+      portfolio: z.string().url().optional(),
+    }),
+    summary: z.string(),
+    work_history: z.array(z.object({
+      company: z.string(),
+      title: z.string(),
+      dates: z.string(),
+      location: z.string().optional(),
+      tech_stack: z.array(z.string()).default([]),
+      bullets: z.array(z.string()).default([]),
+    })),
+    education: z.array(z.object({
+      school: z.string(),
+      program: z.string(),
+      dates: z.string(),
+    })),
+    certifications: z.array(z.object({
+      name: z.string(),
+      issuer: z.string(),
+      year: z.string(),
+    })).default([]),
+    skills: z.object({
+      leadership: z.array(z.string()).default([]),
+      technical: z.array(z.string()).default([]),
+      domain: z.array(z.string()).default([]),
+    }),
+    awards_recognition: z.array(z.object({
+      name: z.string(),
+      org: z.string(),
+      year: z.string(),
+    })).default([]),
+    speaking_writing: z.array(z.object({
+      type: z.enum(['talk', 'article', 'podcast', 'panel']),
+      title: z.string(),
+      venue: z.string(),
+      year: z.string(),
+      url: z.string().url().optional(),
+    })).default([]),
+    languages_spoken: z.array(z.string()).default([]),
+    selected_projects: z.array(z.object({
+      slug: reference('projects'),
+      headline: z.string(),
+    })).default([]),
+  }),
+});
+
+export const collections = { projects, resume };
+```
+
+- [ ] **Step 2: Verify schema parses (no profile.md yet, so collection will be empty):** Run `cd frontend && npx astro check`. Expected: no schema errors. (Warnings about empty collection are acceptable.)
+
+- [ ] **Step 3: Commit:**
+
+```bash
+git add frontend/src/content.config.ts
+git commit -m "feat(p9): add resume content collection schema
+
+Defines the structured schema for profile.md per the design spec —
+required fields (name, title, location, links.linkedin, summary,
+work_history, education, skills) plus optional sections (certifications,
+awards_recognition, speaking_writing, languages_spoken, selected_projects).
+Uses reference('projects') for slug validation against the existing
+projects collection."
+```
+
+### Task 1.2: Create `profile.md` from LinkedIn export
+
+**Files:**
+- Create: `frontend/src/content/resume/profile.md`
+- Reference (read-only, never copied/committed): `/Users/rafaeldeabreugomes/Downloads/rafael_abreu_linkedin_profile.md`
+
+- [ ] **Step 1: Read the LinkedIn export** to extract the source data:
+
+```bash
+cat /Users/rafaeldeabreugomes/Downloads/rafael_abreu_linkedin_profile.md
+```
+
+Extract: name, current and past job titles with dates, descriptions, education entries, certifications, languages.
+
+- [ ] **Step 2: Verify the export file is NOT in the repo and won't be:**
+
+```bash
+git ls-files | grep -i linkedin
+```
+
+Expected: no output. The file lives only at `~/Downloads/`.
+
+- [ ] **Step 3: Write `frontend/src/content/resume/profile.md`** with frontmatter populated from the LinkedIn data. Apply these rules:
+
+  - **Tone:** exec-track — verbs like "Led", "Architected", "Drove", "Owned", "Established", "Scaled". Avoid "helped with", "contributed to", "learned".
+  - **Accuracy:** dates, titles, employers, certifications come verbatim from the LinkedIn export. Bullets paraphrase the LinkedIn descriptions but never invent metrics, scope, or roles not in the source.
+  - **`tech_stack` per work entry:** drawn from technologies mentioned in that job's LinkedIn description. Do not pad with technologies he uses generally.
+  - **`leadership` skills bucket:** populated from leadership signals in LinkedIn job descriptions ("led", "managed", "owned"). Skip if not evidenced.
+  - **`awards_recognition` and `speaking_writing`:** start as empty arrays. They will fill over time.
+  - **`languages_spoken`:** "English (Native)", "Portuguese (Native)" at minimum; check LinkedIn for others.
+  - **`selected_projects`:** reference 2–4 strongest case studies from `frontend/src/content/projects/`. Use slugs that exist in that directory.
+
+Template structure (replace placeholder values with real LinkedIn-derived content):
+
+```markdown
+---
+name: "Rafael Abreu"
+title: "Software Engineer | Engineering Leadership Track"
+location: "Toronto, ON, Canada"
+
+links:
+  linkedin:  "https://www.linkedin.com/in/rafael-abreu"
+  github:    "https://github.com/rfabreu"
+  portfolio: "https://rafaelabreu.netlify.app"
+
+summary: |
+  [Three-sentence executive-positioned summary. Who you are, what
+  you've delivered, where you're heading. Drawn from LinkedIn's
+  About section, sharpened for senior/director/C-level positioning.]
+
+work_history:
+  - company:    "[Verbatim from LinkedIn]"
+    title:      "[Verbatim from LinkedIn]"
+    dates:      "[Verbatim from LinkedIn, format: '2023 — Present']"
+    location:   "[Verbatim from LinkedIn]"
+    tech_stack: ["...", "..."]
+    bullets:
+      - "[Exec-tone paraphrase of LinkedIn bullet — never invents]"
+      - "..."
+  # repeat for each role
+
+education:
+  - school:  "[Verbatim]"
+    program: "[Verbatim]"
+    dates:   "[Verbatim]"
+
+certifications:
+  - name:   "[Verbatim certification name]"
+    issuer: "[Verbatim issuer]"
+    year:   "[Verbatim year]"
+
+skills:
+  leadership:
+    - "[Skills evidenced in LinkedIn job descriptions]"
+  technical:
+    - "[Tech skills consolidated from LinkedIn 'Skills' section + job descriptions]"
+  domain:
+    - "[Industry/domain expertise from LinkedIn]"
+
+awards_recognition: []
+speaking_writing:   []
+
+languages_spoken:
+  - "English (Native)"
+  - "Portuguese (Native)"
+
+selected_projects:
+  - slug:     "[existing project slug from frontend/src/content/projects/]"
+    headline: "[Resume-specific one-line framing]"
+---
+```
+
+- [ ] **Step 4: Validate:** `cd frontend && npx astro check`. Expected: no errors. If `selected_projects.slug` references a non-existent project, the build fails with a useful pointer — fix the slug before continuing.
+
+- [ ] **Step 5: Commit:**
+
+```bash
+git add frontend/src/content/resume/profile.md
+git commit -m "feat(p9): add initial profile.md derived from LinkedIn export
+
+Source data lifted from local LinkedIn export (kept off-repo per
+no-personal-data policy). Tone tuned for exec-track positioning;
+all dates, titles, and employers verbatim from source."
+```
+
+---
+
+## Phase 2: Section Components
+
+These render the structured data into HTML. Each uses Tailwind v4 theme tokens (`text-text-primary`, `bg-surface`, etc.) so dark/light themes work without per-component overrides.
+
+### Task 2.1: Add Vitest for snapshot testing
+
+**Files:**
+- Modify: `frontend/package.json`
+- Create: `frontend/vitest.config.ts`
+- Create: `frontend/tests/setup.ts`
+
+- [ ] **Step 1: Install Vitest:**
+
+```bash
+cd frontend
+npm install --save-dev vitest
+```
+
+Note: the Astro Container API used in component tests is exported from `astro/container` (already a dependency); no extra adapter package is required.
+
+- [ ] **Step 2: Add `test` script to `package.json` "scripts":**
+
+```json
+"test": "vitest run",
+"test:watch": "vitest"
+```
+
+- [ ] **Step 3: Create `frontend/vitest.config.ts`:**
+
+```typescript
+import { defineConfig } from 'vitest/config';
+import { getViteConfig } from 'astro/config';
+
+export default getViteConfig(
+  defineConfig({
+    test: {
+      globals: true,
+      environment: 'node',
+      include: ['tests/**/*.test.ts'],
+    },
+  }),
+);
+```
+
+- [ ] **Step 4: Verify the test runner starts:**
+
+```bash
+cd frontend && npm test
+```
+
+Expected: "No test files found" or similar — runner works, no tests yet. PASS.
+
+- [ ] **Step 5: Commit:**
+
+```bash
+git add frontend/package.json frontend/package-lock.json frontend/vitest.config.ts
+git commit -m "chore(p9): add Vitest for snapshot testing"
+```
+
+### Task 2.2: `Summary.astro` — summary paragraph
+
+**Files:**
+- Create: `frontend/src/components/resume/Summary.astro`
+- Create: `frontend/tests/resume-summary.test.ts`
+
+- [ ] **Step 1: Write the failing test:**
+
+```typescript
+// frontend/tests/resume-summary.test.ts
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { expect, test } from 'vitest';
+import Summary from '../src/components/resume/Summary.astro';
+
+test('Summary renders the summary text in a section element', async () => {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Summary, {
+    props: { summary: 'Engineering leader building distributed systems.' },
+  });
+  expect(html).toContain('<section');
+  expect(html).toContain('Engineering leader building distributed systems.');
+});
+```
+
+- [ ] **Step 2: Run the test, expect failure:**
+
+```bash
+cd frontend && npm test -- resume-summary
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create the component:**
+
+```astro
+---
+// frontend/src/components/resume/Summary.astro
+interface Props {
+  summary: string;
+}
+const { summary } = Astro.props;
+---
+
+<section class="resume-section resume-summary" aria-label="Summary">
+  <p class="text-text-secondary leading-relaxed">{summary}</p>
+</section>
+```
+
+- [ ] **Step 4: Run the test, expect pass:**
+
+```bash
+cd frontend && npm test -- resume-summary
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit:**
+
+```bash
+git add frontend/src/components/resume/Summary.astro frontend/tests/resume-summary.test.ts
+git commit -m "feat(p9): add Summary section component"
+```
+
+### Task 2.3: `Skills.astro` — bucketed skill lists
+
+**Files:**
+- Create: `frontend/src/components/resume/Skills.astro`
+- Create: `frontend/tests/resume-skills.test.ts`
+
+- [ ] **Step 1: Write the failing test:**
+
+```typescript
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { expect, test } from 'vitest';
+import Skills from '../src/components/resume/Skills.astro';
+
+test('Skills renders each non-empty bucket with its label and items', async () => {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Skills, {
+    props: {
+      skills: {
+        leadership: ['Strategic Planning'],
+        technical: ['Go', 'Python'],
+        domain: [],
+      },
+    },
+  });
+  expect(html).toContain('Leadership');
+  expect(html).toContain('Strategic Planning');
+  expect(html).toContain('Technical');
+  expect(html).toContain('Go');
+  expect(html).toContain('Python');
+  expect(html).not.toContain('Domain');  // empty bucket skipped
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** (`cd frontend && npm test -- resume-skills`).
+
+- [ ] **Step 3: Create the component:**
+
+```astro
+---
+// frontend/src/components/resume/Skills.astro
+interface Props {
+  skills: {
+    leadership: string[];
+    technical: string[];
+    domain: string[];
+  };
+}
+const { skills } = Astro.props;
+
+const buckets: Array<{ key: keyof typeof skills; label: string }> = [
+  { key: 'leadership', label: 'Leadership' },
+  { key: 'technical', label: 'Technical' },
+  { key: 'domain', label: 'Domain' },
+];
+---
+
+<section class="resume-section resume-skills" aria-label="Skills">
+  <h2 class="resume-heading">Skills</h2>
+  {buckets.map(({ key, label }) => (
+    skills[key].length > 0 && (
+      <div class="resume-skill-bucket">
+        <h3 class="resume-skill-label">{label}</h3>
+        <ul class="resume-skill-list">
+          {skills[key].map((skill) => <li>{skill}</li>)}
+        </ul>
+      </div>
+    )
+  ))}
+</section>
+```
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit:**
+
+```bash
+git add frontend/src/components/resume/Skills.astro frontend/tests/resume-skills.test.ts
+git commit -m "feat(p9): add Skills section component"
+```
+
+### Task 2.4: `WorkHistory.astro` — jobs with bullets and tech_stack
+
+**Files:**
+- Create: `frontend/src/components/resume/WorkHistory.astro`
+- Create: `frontend/tests/resume-work-history.test.ts`
+
+- [ ] **Step 1: Failing test:**
+
+```typescript
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { expect, test } from 'vitest';
+import WorkHistory from '../src/components/resume/WorkHistory.astro';
+
+test('WorkHistory renders each job with title, company, dates, bullets, tech_stack', async () => {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(WorkHistory, {
+    props: {
+      entries: [
+        {
+          company: 'Nextologies',
+          title: 'Software Engineer',
+          dates: '2023 — Present',
+          location: 'Toronto, ON',
+          tech_stack: ['Go', 'Kubernetes'],
+          bullets: ['Architected the platform.'],
+        },
+      ],
+    },
+  });
+  expect(html).toContain('Nextologies');
+  expect(html).toContain('Software Engineer');
+  expect(html).toContain('2023 — Present');
+  expect(html).toContain('Toronto, ON');
+  expect(html).toContain('Architected the platform.');
+  expect(html).toContain('Go');
+  expect(html).toContain('Kubernetes');
+});
+
+test('WorkHistory handles empty bullets and missing location gracefully', async () => {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(WorkHistory, {
+    props: {
+      entries: [
+        {
+          company: 'Acme',
+          title: 'Engineer',
+          dates: '2020 — 2022',
+          tech_stack: [],
+          bullets: [],
+        },
+      ],
+    },
+  });
+  expect(html).toContain('Acme');
+  expect(html).not.toContain('<ul');  // no bullet list when empty
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Create the component:**
+
+```astro
+---
+// frontend/src/components/resume/WorkHistory.astro
+interface Entry {
+  company: string;
+  title: string;
+  dates: string;
+  location?: string;
+  tech_stack: string[];
+  bullets: string[];
+}
+
+interface Props {
+  entries: Entry[];
+}
+
+const { entries } = Astro.props;
+---
+
+<section class="resume-section resume-work-history" aria-label="Work history">
+  <h2 class="resume-heading">Experience</h2>
+  {entries.map((entry) => (
+    <article class="resume-job">
+      <header class="resume-job-header">
+        <div class="resume-job-title-row">
+          <span class="resume-job-title">{entry.title}</span>
+          <span class="resume-job-company">{entry.company}</span>
+        </div>
+        <div class="resume-job-meta">
+          <span class="resume-job-dates">{entry.dates}</span>
+          {entry.location && <span class="resume-job-location"> · {entry.location}</span>}
+        </div>
+      </header>
+      {entry.bullets.length > 0 && (
+        <ul class="resume-job-bullets">
+          {entry.bullets.map((b) => <li>{b}</li>)}
+        </ul>
+      )}
+      {entry.tech_stack.length > 0 && (
+        <div class="resume-job-tech">
+          {entry.tech_stack.map((tech) => <span class="resume-tech-tag">{tech}</span>)}
+        </div>
+      )}
+    </article>
+  ))}
+</section>
+```
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit:**
+
+```bash
+git add frontend/src/components/resume/WorkHistory.astro frontend/tests/resume-work-history.test.ts
+git commit -m "feat(p9): add WorkHistory section component"
+```
+
+### Task 2.5: `Education.astro` — education entries
+
+**Files:**
+- Create: `frontend/src/components/resume/Education.astro`
+- Create: `frontend/tests/resume-education.test.ts`
+
+- [ ] **Step 1: Failing test:**
+
+```typescript
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { expect, test } from 'vitest';
+import Education from '../src/components/resume/Education.astro';
+
+test('Education renders school, program, and dates per entry', async () => {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Education, {
+    props: {
+      entries: [
+        { school: 'University of Toronto', program: 'Coding Bootcamp', dates: '2022 — 2023' },
+      ],
+    },
+  });
+  expect(html).toContain('University of Toronto');
+  expect(html).toContain('Coding Bootcamp');
+  expect(html).toContain('2022 — 2023');
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Create the component:**
+
+```astro
+---
+// frontend/src/components/resume/Education.astro
+interface Entry {
+  school: string;
+  program: string;
+  dates: string;
+}
+interface Props {
+  entries: Entry[];
+}
+const { entries } = Astro.props;
+---
+
+{entries.length > 0 && (
+  <section class="resume-section resume-education" aria-label="Education">
+    <h2 class="resume-heading">Education</h2>
+    <ul class="resume-list">
+      {entries.map((entry) => (
+        <li>
+          <span class="resume-edu-school">{entry.school}</span>
+          <span class="resume-edu-program"> — {entry.program}</span>
+          <span class="resume-edu-dates"> ({entry.dates})</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+)}
+```
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit:**
+
+```bash
+git add frontend/src/components/resume/Education.astro frontend/tests/resume-education.test.ts
+git commit -m "feat(p9): add Education section component"
+```
+
+### Task 2.6: `Certifications.astro`, `Awards.astro`, `Speaking.astro` — list-shaped sections
+
+**Files:**
+- Create: `frontend/src/components/resume/Certifications.astro`
+- Create: `frontend/src/components/resume/Awards.astro`
+- Create: `frontend/src/components/resume/Speaking.astro`
+- Create: `frontend/tests/resume-list-sections.test.ts`
+
+These three sections are structurally similar — each renders a list of records and skips itself when empty.
+
+- [ ] **Step 1: Failing test (covers all three components):**
+
+```typescript
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { expect, test } from 'vitest';
+import Certifications from '../src/components/resume/Certifications.astro';
+import Awards from '../src/components/resume/Awards.astro';
+import Speaking from '../src/components/resume/Speaking.astro';
+
+test('Certifications renders entries with name/issuer/year, omits when empty', async () => {
+  const container = await AstroContainer.create();
+  const withEntries = await container.renderToString(Certifications, {
+    props: { entries: [{ name: 'OpenShift Specialist', issuer: 'Red Hat', year: '2024' }] },
+  });
+  expect(withEntries).toContain('OpenShift Specialist');
+  expect(withEntries).toContain('Red Hat');
+  expect(withEntries).toContain('2024');
+
+  const empty = await container.renderToString(Certifications, { props: { entries: [] } });
+  expect(empty.trim()).toBe('');
+});
+
+test('Awards renders entries with name/org/year, omits when empty', async () => {
+  const container = await AstroContainer.create();
+  const withEntries = await container.renderToString(Awards, {
+    props: { entries: [{ name: 'Hackathon Winner', org: 'TechFest', year: '2025' }] },
+  });
+  expect(withEntries).toContain('Hackathon Winner');
+  expect(withEntries).toContain('TechFest');
+
+  const empty = await container.renderToString(Awards, { props: { entries: [] } });
+  expect(empty.trim()).toBe('');
+});
+
+test('Speaking renders entries with title/venue/year and link when present, omits when empty', async () => {
+  const container = await AstroContainer.create();
+  const withEntries = await container.renderToString(Speaking, {
+    props: {
+      entries: [
+        { type: 'talk', title: 'Building with Go', venue: 'GoTO Meetup', year: '2026', url: 'https://example.com/talk' },
+      ],
+    },
+  });
+  expect(withEntries).toContain('Building with Go');
+  expect(withEntries).toContain('GoTO Meetup');
+  expect(withEntries).toContain('href="https://example.com/talk"');
+
+  const empty = await container.renderToString(Speaking, { props: { entries: [] } });
+  expect(empty.trim()).toBe('');
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Create `Certifications.astro`:**
+
+```astro
+---
+interface Entry { name: string; issuer: string; year: string; }
+interface Props { entries: Entry[]; }
+const { entries } = Astro.props;
+---
+
+{entries.length > 0 && (
+  <section class="resume-section resume-certifications" aria-label="Certifications">
+    <h2 class="resume-heading">Certifications</h2>
+    <ul class="resume-list">
+      {entries.map((entry) => (
+        <li>
+          <span class="resume-cert-name">{entry.name}</span>
+          <span class="resume-cert-meta"> — {entry.issuer} ({entry.year})</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+)}
+```
+
+- [ ] **Step 4: Create `Awards.astro`:**
+
+```astro
+---
+interface Entry { name: string; org: string; year: string; }
+interface Props { entries: Entry[]; }
+const { entries } = Astro.props;
+---
+
+{entries.length > 0 && (
+  <section class="resume-section resume-awards" aria-label="Awards & Recognition">
+    <h2 class="resume-heading">Awards &amp; Recognition</h2>
+    <ul class="resume-list">
+      {entries.map((entry) => (
+        <li>
+          <span class="resume-award-name">{entry.name}</span>
+          <span class="resume-award-meta"> — {entry.org} ({entry.year})</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+)}
+```
+
+- [ ] **Step 5: Create `Speaking.astro`:**
+
+```astro
+---
+interface Entry {
+  type: 'talk' | 'article' | 'podcast' | 'panel';
+  title: string;
+  venue: string;
+  year: string;
+  url?: string;
+}
+interface Props { entries: Entry[]; }
+const { entries } = Astro.props;
+---
+
+{entries.length > 0 && (
+  <section class="resume-section resume-speaking" aria-label="Speaking & Writing">
+    <h2 class="resume-heading">Speaking &amp; Writing</h2>
+    <ul class="resume-list">
+      {entries.map((entry) => (
+        <li>
+          {entry.url ? (
+            <a href={entry.url} class="resume-speaking-link">{entry.title}</a>
+          ) : (
+            <span>{entry.title}</span>
+          )}
+          <span class="resume-speaking-meta"> — {entry.venue} ({entry.year})</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+)}
+```
+
+- [ ] **Step 6: Run, expect PASS.**
+
+- [ ] **Step 7: Commit:**
+
+```bash
+git add frontend/src/components/resume/Certifications.astro frontend/src/components/resume/Awards.astro frontend/src/components/resume/Speaking.astro frontend/tests/resume-list-sections.test.ts
+git commit -m "feat(p9): add Certifications, Awards, and Speaking section components"
+```
+
+### Task 2.7: `Languages.astro` — languages spoken
+
+**Files:**
+- Create: `frontend/src/components/resume/Languages.astro`
+- Create: `frontend/tests/resume-languages.test.ts`
+
+- [ ] **Step 1: Failing test:**
+
+```typescript
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { expect, test } from 'vitest';
+import Languages from '../src/components/resume/Languages.astro';
+
+test('Languages renders each entry inline; omits when empty', async () => {
+  const container = await AstroContainer.create();
+  const withEntries = await container.renderToString(Languages, {
+    props: { entries: ['English (Native)', 'Portuguese (Native)'] },
+  });
+  expect(withEntries).toContain('English (Native)');
+  expect(withEntries).toContain('Portuguese (Native)');
+
+  const empty = await container.renderToString(Languages, { props: { entries: [] } });
+  expect(empty.trim()).toBe('');
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Create the component:**
+
+```astro
+---
+interface Props { entries: string[]; }
+const { entries } = Astro.props;
+---
+
+{entries.length > 0 && (
+  <section class="resume-section resume-languages" aria-label="Languages">
+    <h2 class="resume-heading">Languages</h2>
+    <p class="resume-languages-list">{entries.join(' · ')}</p>
+  </section>
+)}
+```
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit:**
+
+```bash
+git add frontend/src/components/resume/Languages.astro frontend/tests/resume-languages.test.ts
+git commit -m "feat(p9): add Languages section component"
+```
+
+### Task 2.8: `Projects.astro` — selected projects with case-study links
+
+**Files:**
+- Create: `frontend/src/components/resume/Projects.astro`
+- Create: `frontend/tests/resume-projects.test.ts`
+
+- [ ] **Step 1: Failing test:**
+
+```typescript
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { expect, test } from 'vitest';
+import Projects from '../src/components/resume/Projects.astro';
+
+test('Projects renders headline and links to case study by slug', async () => {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Projects, {
+    props: {
+      entries: [
+        { slug: 'fptv', headline: 'Glassmorphism dashboard for Toronto TV broadcaster' },
+      ],
+    },
+  });
+  expect(html).toContain('Glassmorphism dashboard for Toronto TV broadcaster');
+  expect(html).toContain('href="/project/fptv"');
+});
+
+test('Projects omits section when entries is empty', async () => {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Projects, { props: { entries: [] } });
+  expect(html.trim()).toBe('');
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Create the component:**
+
+```astro
+---
+interface Entry { slug: string; headline: string; }
+interface Props { entries: Entry[]; }
+const { entries } = Astro.props;
+---
+
+{entries.length > 0 && (
+  <section class="resume-section resume-projects" aria-label="Selected projects">
+    <h2 class="resume-heading">Selected Projects</h2>
+    <ul class="resume-list">
+      {entries.map((entry) => (
+        <li>
+          <a href={`/project/${entry.slug}`} class="resume-project-link">
+            {entry.headline}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </section>
+)}
+```
+
+Note: `entry.slug` here is already the resolved string from the `reference()` helper because we'll convert the `DataEntryMap` shape to plain props in `ResumeBody.astro` (Task 3.1). Astro's `reference()` validates at build time but the runtime value is `{ collection, id }`, so the assembler will call `.id` to extract the slug string before passing to this component.
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit:**
+
+```bash
+git add frontend/src/components/resume/Projects.astro frontend/tests/resume-projects.test.ts
+git commit -m "feat(p9): add Projects section component"
+```
+
+---
+
+## Phase 3: Wrappers — `ResumeBody.astro` and `/resume` page
+
+### Task 3.1: `ResumeBody.astro` — assembles all sections
+
+**Files:**
+- Create: `frontend/src/components/resume/ResumeBody.astro`
+
+- [ ] **Step 1: Create the assembler component:**
+
+```astro
+---
+// frontend/src/components/resume/ResumeBody.astro
+import type { CollectionEntry } from 'astro:content';
+import Summary from './Summary.astro';
+import Skills from './Skills.astro';
+import WorkHistory from './WorkHistory.astro';
+import Education from './Education.astro';
+import Certifications from './Certifications.astro';
+import Awards from './Awards.astro';
+import Speaking from './Speaking.astro';
+import Languages from './Languages.astro';
+import Projects from './Projects.astro';
+
+interface Props {
+  resume: CollectionEntry<'resume'>;
+}
+const { resume } = Astro.props;
+const data = resume.data;
+
+const projectEntries = data.selected_projects.map((p) => ({
+  slug: p.slug.id,
+  headline: p.headline,
+}));
+---
+
+<div class="resume-body">
+  <Summary summary={data.summary} />
+  <Skills skills={data.skills} />
+  <WorkHistory entries={data.work_history} />
+  <Education entries={data.education} />
+  <Certifications entries={data.certifications} />
+  <Awards entries={data.awards_recognition} />
+  <Speaking entries={data.speaking_writing} />
+  <Languages entries={data.languages_spoken} />
+  <Projects entries={projectEntries} />
+</div>
+```
+
+- [ ] **Step 2: Verify type-check:** `cd frontend && npx astro check`. Expected: no errors.
+
+- [ ] **Step 3: Commit:**
+
+```bash
+git add frontend/src/components/resume/ResumeBody.astro
+git commit -m "feat(p9): add ResumeBody assembler"
+```
+
+### Task 3.2: `/resume` standalone page
+
+**Files:**
+- Create: `frontend/src/pages/resume.astro`
+
+- [ ] **Step 1: Create the page:**
+
+```astro
+---
+// frontend/src/pages/resume.astro
+import { getEntry } from 'astro:content';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import ResumeBody from '../components/resume/ResumeBody.astro';
+
+const resume = await getEntry('resume', 'profile');
+if (!resume) throw new Error('Resume entry not found at frontend/src/content/resume/profile.md');
+---
+
+<BaseLayout
+  title={`${resume.data.name} — Resume`}
+  description={`Resume for ${resume.data.name}, ${resume.data.title}.`}
+  includeResumeModal={false}
+>
+  <main class="resume-page">
+    <header class="resume-page-header">
+      <h1 class="resume-page-name">{resume.data.name}</h1>
+      <p class="resume-page-title">{resume.data.title}</p>
+      <p class="resume-page-location">{resume.data.location}</p>
+      <p class="resume-page-links">
+        <a href={resume.data.links.linkedin}>LinkedIn</a>
+        {resume.data.links.github && <> · <a href={resume.data.links.github}>GitHub</a></>}
+        {resume.data.links.portfolio && <> · <a href={resume.data.links.portfolio}>Portfolio</a></>}
+      </p>
+    </header>
+    <ResumeBody resume={resume} />
+    <footer class="resume-page-footer">
+      <p>Contact via <a href="/#contact">contact form</a> or <a href={resume.data.links.linkedin}>LinkedIn</a>.</p>
+    </footer>
+  </main>
+</BaseLayout>
+```
+
+- [ ] **Step 2: Run dev server and visit `/resume`:**
+
+```bash
+cd frontend && npm run dev
+```
+
+Open `http://localhost:4321/resume` in browser. Confirm:
+- Resume content renders without errors
+- All section data appears correctly
+- Stop the dev server with Ctrl+C
+
+- [ ] **Step 3: Commit:**
+
+```bash
+git add frontend/src/pages/resume.astro
+git commit -m "feat(p9): add /resume standalone page"
+```
+
+### Task 3.3: Add resume styling to `global.css`
+
+**Files:**
+- Modify: `frontend/src/styles/global.css`
+
+- [ ] **Step 1: Read the current global.css** to understand the existing token system:
+
+```bash
+cat frontend/src/styles/global.css
+```
+
+- [ ] **Step 2: Append the resume style block** at the bottom of `global.css`:
+
+```css
+/* ===== Resume ===== */
+
+/* Page (used standalone at /resume and as the print source for the PDF) */
+.resume-page {
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  color: var(--color-text-primary);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  line-height: 1.6;
+}
+
+.resume-page-header {
+  margin-bottom: 2.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--color-surface-border);
+}
+
+.resume-page-name {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  margin-bottom: 0.25rem;
+}
+
+.resume-page-title {
+  font-size: 1.125rem;
+  color: var(--color-text-secondary);
+  margin-bottom: 0.5rem;
+}
+
+.resume-page-location,
+.resume-page-links {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+.resume-page-links a {
+  color: var(--color-accent-indigo);
+  text-decoration: none;
+}
+
+.resume-page-links a:hover { text-decoration: underline; }
+
+.resume-page-footer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-surface-border);
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+.resume-page-footer a { color: var(--color-accent-indigo); }
+
+/* Sections */
+.resume-section { margin-top: 2rem; }
+.resume-heading {
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-accent-indigo);
+  margin-bottom: 0.75rem;
+}
+
+/* Work history */
+.resume-job { margin-bottom: 1.5rem; }
+.resume-job-header { margin-bottom: 0.5rem; }
+.resume-job-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.resume-job-title { font-weight: 600; }
+.resume-job-company { color: var(--color-text-secondary); }
+.resume-job-meta {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+.resume-job-bullets {
+  list-style: disc;
+  padding-left: 1.5rem;
+  margin-top: 0.5rem;
+}
+.resume-job-bullets li { margin-bottom: 0.25rem; }
+.resume-job-tech {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin-top: 0.5rem;
+}
+.resume-tech-tag {
+  display: inline-block;
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-border);
+  border-radius: 0.25rem;
+  color: var(--color-text-secondary);
+}
+
+/* Skills */
+.resume-skill-bucket { margin-bottom: 0.75rem; }
+.resume-skill-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin-bottom: 0.25rem;
+}
+.resume-skill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem 0.75rem;
+  list-style: none;
+  padding: 0;
+}
+.resume-skill-list li { color: var(--color-text-secondary); }
+.resume-skill-list li:not(:last-child)::after {
+  content: '·';
+  margin-left: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+/* Generic list */
+.resume-list { list-style: none; padding: 0; }
+.resume-list li { margin-bottom: 0.375rem; }
+
+/* Modal */
+.resume-modal {
+  background: var(--color-base);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-surface-border);
+  border-radius: 0.75rem;
+  padding: 0;
+  max-width: 56rem;
+  width: 90vw;
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.resume-modal::backdrop {
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+}
+.resume-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--color-surface-border);
+  flex-shrink: 0;
+}
+.resume-modal-title { display: flex; flex-direction: column; }
+.resume-modal-title .name { font-weight: 700; }
+.resume-modal-title .title { font-size: 0.875rem; color: var(--color-text-muted); }
+.resume-modal-actions { display: flex; gap: 0.5rem; align-items: center; }
+.btn-download {
+  padding: 0.375rem 0.875rem;
+  background: var(--color-accent-indigo);
+  color: white;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  text-decoration: none;
+}
+.btn-download:hover { opacity: 0.9; }
+.btn-close {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  line-height: 1;
+}
+.btn-close:hover { color: var(--color-text-primary); }
+.resume-modal-body {
+  overflow-y: auto;
+  padding: 1.5rem;
+}
+.resume-modal-footer {
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--color-surface-border);
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+.resume-modal-footer a { color: var(--color-accent-indigo); }
+
+/* Print stylesheet — used by Playwright when generating the PDF */
+@media print {
+  /* Hide site chrome on the /resume page when printing */
+  header, footer.site-footer, nav { display: none !important; }
+  .resume-page { max-width: none; padding: 0; }
+  .resume-page-header { border-bottom-color: #ccc; }
+  .resume-section { page-break-inside: avoid; }
+  .resume-heading { color: #4f46e5; }
+  body { background: white; color: black; }
+  a { color: #4f46e5; text-decoration: none; }
+  .resume-tech-tag {
+    background: #f5f5f5;
+    border-color: #ddd;
+    color: #444;
+  }
+}
+```
+
+- [ ] **Step 3: Visit `http://localhost:4321/resume`** in `npm run dev` to confirm the styles apply correctly. Use browser print preview (Cmd+P) to confirm the print stylesheet looks good.
+
+- [ ] **Step 4: Commit:**
+
+```bash
+git add frontend/src/styles/global.css
+git commit -m "feat(p9): add resume styles for page, modal, and print"
+```
+
+---
+
+## Phase 4: Modal & Nav Integration
+
+### Task 4.1: `ResumeModal.astro`
+
+**Files:**
+- Create: `frontend/src/components/ResumeModal.astro`
+
+- [ ] **Step 1: Create the modal component:**
+
+```astro
+---
+// frontend/src/components/ResumeModal.astro
+import { getEntry } from 'astro:content';
+import ResumeBody from './resume/ResumeBody.astro';
+
+const resume = await getEntry('resume', 'profile');
+if (!resume) throw new Error('Resume entry not found at frontend/src/content/resume/profile.md');
+---
+
+<dialog id="resume-modal" class="resume-modal">
+  <header class="resume-modal-header">
+    <div class="resume-modal-title">
+      <span class="name">{resume.data.name}</span>
+      <span class="title">{resume.data.title}</span>
+    </div>
+    <div class="resume-modal-actions">
+      <a href="/Rafael_Abreu_Resume.pdf" download class="btn-download">Download PDF</a>
+      <button type="button" class="btn-close" aria-label="Close resume">×</button>
+    </div>
+  </header>
+  <div class="resume-modal-body">
+    <ResumeBody resume={resume} />
+  </div>
+  <footer class="resume-modal-footer">
+    Contact via <a href="/#contact">contact form</a> or
+    <a href={resume.data.links.linkedin} target="_blank" rel="noopener noreferrer">LinkedIn →</a>
+  </footer>
+</dialog>
+
+<script>
+  const modal = document.getElementById('resume-modal') as HTMLDialogElement | null;
+
+  // Event delegation handles both static Astro Nav anchors and React-hydrated MobileNav buttons.
+  document.addEventListener('click', (e) => {
+    const trigger = (e.target as HTMLElement)?.closest('[data-resume-trigger]');
+    if (trigger) {
+      e.preventDefault();
+      modal?.showModal();
+    }
+  });
+
+  modal?.querySelector('.btn-close')?.addEventListener('click', () => modal.close());
+  modal?.addEventListener('click', (e) => {
+    if (e.target === modal) modal.close();
+  });
+</script>
+```
+
+- [ ] **Step 2: Verify type-check:** `cd frontend && npx astro check`. Expected: no errors.
+
+- [ ] **Step 3: Commit:**
+
+```bash
+git add frontend/src/components/ResumeModal.astro
+git commit -m "feat(p9): add ResumeModal component"
+```
+
+### Task 4.2: BaseLayout integration with opt-out prop
+
+**Files:**
+- Modify: `frontend/src/layouts/BaseLayout.astro`
+
+- [ ] **Step 1: Update the layout to include the modal site-wide with an opt-out prop:**
+
+Replace the current `interface Props` and `Astro.props` destructure, and add the modal include before `</body>`:
+
+```astro
+---
+import '../styles/global.css';
+import ResumeModal from '../components/ResumeModal.astro';
+
+interface Props {
+  title?: string;
+  description?: string;
+  includeResumeModal?: boolean;
+}
+
+const {
+  title = 'Rafael Abreu | Software Engineer',
+  description = 'Software Engineer building intelligent systems across the full stack. Go, Python, React, and the infrastructure that connects them.',
+  includeResumeModal = true,
+} = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content={description} />
+    <meta name="theme-color" content="#050508" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <title>{title}</title>
+    <script is:inline>
+      (function() {
+        var theme = localStorage.getItem('theme');
+        if (!theme) {
+          theme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+        }
+        document.documentElement.dataset.theme = theme;
+        var meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) meta.setAttribute('content', theme === 'light' ? '#F8F7F4' : '#050508');
+      })();
+    </script>
+    {import.meta.env.PROD && <script is:inline async src="https://cloud.umami.is/script.js" data-website-id="f17cb708-288b-471b-989f-d7115bfcbec4"></script>}
+  </head>
+  <body>
+    <slot />
+
+    {includeResumeModal && <ResumeModal />}
+
+    <script>
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              entry.target.classList.add('visible');
+              observer.unobserve(entry.target);
+            }
+          });
+        },
+        { threshold: 0.1 }
+      );
+      document.querySelectorAll('.reveal').forEach((el) => observer.observe(el));
+    </script>
+  </body>
+</html>
+```
+
+- [ ] **Step 2: Run dev server and verify the modal renders** (it'll be hidden until triggered): `cd frontend && npm run dev`. Open the homepage, run in console: `document.getElementById('resume-modal').showModal()`. Modal should appear with content. Stop dev server.
+
+- [ ] **Step 3: Commit:**
+
+```bash
+git add frontend/src/layouts/BaseLayout.astro
+git commit -m "feat(p9): include ResumeModal in BaseLayout with opt-out prop"
+```
+
+### Task 4.3: Update `Nav.astro`
+
+**Files:**
+- Modify: `frontend/src/components/Nav.astro`
+
+- [ ] **Step 1: Replace the contents:**
+
+```astro
+---
+import MobileNav from '../islands/MobileNav.tsx';
+import ThemeToggle from '../islands/ThemeToggle.tsx';
+
+const navItems = [
+  { label: 'About', href: '/#about' },
+  { label: 'Projects', href: '/#projects' },
+  { label: 'Skills', href: '/#skills' },
+  { label: 'Playground', href: '/playground' },
+  { label: 'Contact', href: '/#contact' },
+];
+
+const isResumePage = Astro.url.pathname === '/resume';
+---
+
+<header class="sticky top-0 z-50 bg-base/80 backdrop-blur-md border-b border-surface-border">
+  <nav class="container mx-auto max-w-6xl px-6 py-4 flex items-center justify-between">
+    <a href="/" class="font-mono text-text-primary text-sm font-bold tracking-wide">
+      RA<span class="text-accent-indigo">.</span>
+    </a>
+
+    <div class="hidden md:flex items-center gap-7">
+      {navItems.map((item) => (
+        <a
+          href={item.href}
+          class="text-text-muted text-xs tracking-[1.5px] uppercase hover:text-accent-indigo transition-colors duration-200"
+        >
+          {item.label}
+        </a>
+      ))}
+    </div>
+
+    <div class="hidden md:flex items-center gap-3">
+      <ThemeToggle client:load />
+      {!isResumePage && (
+        <a
+          href="/resume"
+          data-resume-trigger
+          class="px-4 py-1.5 border border-accent-indigo/40 rounded-btn text-accent-indigo text-xs tracking-wide hover:bg-accent-indigo/10 transition-colors duration-200"
+        >
+          RESUME
+        </a>
+      )}
+      <a
+        href="/#contact"
+        class="px-4 py-1.5 bg-accent-indigo rounded-btn text-white text-xs tracking-wide hover:bg-accent-indigo/90 transition-colors duration-200"
+      >
+        LET'S TALK
+      </a>
+    </div>
+
+    <MobileNav client:load navItems={navItems} isResumePage={isResumePage} />
+  </nav>
+</header>
+```
+
+Notes:
+- The Resume link uses `href="/resume"` so users who somehow click it without the modal listener installed (e.g., on `/resume` itself, or with JS disabled) navigate to the standalone page. The `data-resume-trigger` attribute is what the modal script catches to override that navigation.
+- `Astro.url.pathname` lets the Nav suppress the Resume button on `/resume`.
+
+- [ ] **Step 2: Verify dev server still renders the home page correctly** and clicking RESUME opens the modal: `cd frontend && npm run dev`, visit `http://localhost:4321/`, click RESUME button. Modal should open. Visit `http://localhost:4321/resume` directly — RESUME button should be hidden.
+
+- [ ] **Step 3: Commit:**
+
+```bash
+git add frontend/src/components/Nav.astro
+git commit -m "feat(p9): wire Nav RESUME button to modal trigger; hide on /resume"
+```
+
+### Task 4.4: Update `MobileNav.tsx`
+
+**Files:**
+- Modify: `frontend/src/islands/MobileNav.tsx`
+
+- [ ] **Step 1: Replace the file contents:**
+
+```tsx
+import { useState } from 'react';
+import ThemeToggle from './ThemeToggle';
+
+interface NavItem {
+  label: string;
+  href: string;
+}
+
+interface Props {
+  navItems: NavItem[];
+  isResumePage: boolean;
+}
+
+export default function MobileNav({ navItems, isResumePage }: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="md:hidden">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="relative z-50 w-8 h-8 flex flex-col justify-center items-center gap-1.5"
+        aria-label={isOpen ? 'Close menu' : 'Open menu'}
+      >
+        <span
+          className={`block w-5 h-0.5 bg-text-primary transition-all duration-300 ${
+            isOpen ? 'rotate-45 translate-y-1' : ''
+          }`}
+        />
+        <span
+          className={`block w-5 h-0.5 bg-text-primary transition-all duration-300 ${
+            isOpen ? '-rotate-45 -translate-y-1' : ''
+          }`}
+        />
+      </button>
+
+      {isOpen && (
+        <div className="fixed inset-0 z-40 bg-base flex flex-col items-center justify-center gap-8">
+          <div className="absolute top-5 right-14">
+            <ThemeToggle />
+          </div>
+          {navItems.map((item) => (
+            <a
+              key={item.label}
+              href={item.href}
+              onClick={() => setIsOpen(false)}
+              className="text-text-primary text-2xl font-bold hover:text-accent-indigo transition-colors"
+              style={{ letterSpacing: '-0.06em' }}
+            >
+              {item.label}
+            </a>
+          ))}
+          <div className="flex gap-4 mt-4">
+            {!isResumePage && (
+              <a
+                href="/resume"
+                data-resume-trigger
+                onClick={() => setIsOpen(false)}
+                className="px-6 py-2 border border-accent-indigo/40 rounded-lg text-accent-indigo text-sm"
+              >
+                RESUME
+              </a>
+            )}
+            <a
+              href="/#contact"
+              onClick={() => setIsOpen(false)}
+              className="px-6 py-2 bg-accent-indigo rounded-lg text-white text-sm"
+            >
+              LET'S TALK
+            </a>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify on a mobile viewport** in the dev server (`cd frontend && npm run dev`, then resize browser narrow or use device-emulation). Tap the hamburger, tap RESUME — modal should open.
+
+- [ ] **Step 3: Commit:**
+
+```bash
+git add frontend/src/islands/MobileNav.tsx
+git commit -m "feat(p9): wire MobileNav RESUME button to modal trigger; hide on /resume"
+```
+
+---
+
+## Phase 5: PDF Generation in CI
+
+### Task 5.1: Add Playwright and serve-handler
+
+**Files:**
+- Modify: `frontend/package.json`
+
+- [ ] **Step 1: Install:**
+
+```bash
+cd frontend
+npm install --save-dev playwright serve-handler
+```
+
+- [ ] **Step 2: Install Chromium for Playwright** (one-time, used locally; in CI we install fresh):
+
+```bash
+npx playwright install chromium
+```
+
+- [ ] **Step 3: Commit:**
+
+```bash
+git add frontend/package.json frontend/package-lock.json
+git commit -m "chore(p9): add Playwright and serve-handler for PDF generation"
+```
+
+### Task 5.2: Write the PDF generator script
+
+**Files:**
+- Create: `frontend/scripts/generate-pdf.mjs`
+
+- [ ] **Step 1: Create the script:**
+
+```javascript
+// frontend/scripts/generate-pdf.mjs
+import { chromium } from 'playwright';
+import { createServer } from 'http';
+import handler from 'serve-handler';
+import { resolve } from 'path';
+
+const distPath = resolve('dist');
+const outputPath = resolve('dist', 'Rafael_Abreu_Resume.pdf');
+
+const server = createServer((req, res) => handler(req, res, { public: distPath }));
+// Port 0 = OS-assigned free port. Avoids collision with Astro's default dev port (4321).
+await new Promise((resolve) => server.listen(0, resolve));
+const { port } = server.address();
+
+const browser = await chromium.launch();
+try {
+  const page = await browser.newPage();
+  await page.goto(`http://localhost:${port}/resume`, { waitUntil: 'load' });
+  await page.emulateMedia({ media: 'print' });
+  await page.pdf({
+    path: outputPath,
+    format: 'A4',
+    printBackground: true,
+    margin: { top: '0.5in', right: '0.5in', bottom: '0.5in', left: '0.5in' },
+  });
+  console.log(`PDF written to ${outputPath}`);
+} finally {
+  await browser.close();
+  server.close();
+}
+```
+
+- [ ] **Step 2: Add npm script to `package.json`** under "scripts":
+
+```json
+"build:pdf": "node scripts/generate-pdf.mjs"
+```
+
+- [ ] **Step 3: Test locally:**
+
+```bash
+cd frontend
+npm run build       # produce dist/
+npm run build:pdf   # produce dist/Rafael_Abreu_Resume.pdf
+ls -la dist/Rafael_Abreu_Resume.pdf
+```
+
+Expected: file exists, > 10KB. Open it manually to eyeball the layout.
+
+- [ ] **Step 4: Commit:**
+
+```bash
+git add frontend/scripts/generate-pdf.mjs frontend/package.json
+git commit -m "feat(p9): add Playwright-based PDF generator script"
+```
+
+### Task 5.3: Update frontend deploy workflow
+
+**Files:**
+- Modify: `.github/workflows/deploy-frontend.yml`
+
+- [ ] **Step 1: Replace the file contents:**
+
+```yaml
+name: Deploy Frontend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+
+jobs:
+  deploy:
+    name: Deploy to Netlify
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          PUBLIC_API_URL: ${{ secrets.PUBLIC_API_URL }}
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Generate Resume PDF
+        run: npm run build:pdf
+
+      - name: Verify PDF was generated
+        run: |
+          test -f dist/Rafael_Abreu_Resume.pdf
+          test "$(stat -c%s dist/Rafael_Abreu_Resume.pdf)" -gt 10240
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v3
+        with:
+          publish-dir: frontend/dist
+          production-deploy: true
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+```
+
+- [ ] **Step 2: Lint the YAML:**
+
+```bash
+cd /Users/rafaeldeabreugomes/projects/portfolio
+yq eval '.github/workflows/deploy-frontend.yml' > /dev/null  # if yq is available
+```
+
+(If `yq` isn't installed, skip — the actual validation happens when GitHub parses it on next run.)
+
+- [ ] **Step 3: Commit:**
+
+```bash
+git add .github/workflows/deploy-frontend.yml
+git commit -m "ci(p9): generate resume PDF in deploy-frontend pipeline"
+```
+
+---
+
+## Phase 6: Chatbot Integration
+
+### Task 6.1: Add API gitignore for embedded directory
+
+**Files:**
+- Create: `api/.gitignore`
+
+- [ ] **Step 1: Create the file:**
+
+```
+# Build artifacts mirroring frontend content (populated by `make sync-content`)
+internal/chat/embedded/
+```
+
+- [ ] **Step 2: Commit:**
+
+```bash
+git add api/.gitignore
+git commit -m "chore(p9): add api/.gitignore for embedded build artifacts"
+```
+
+### Task 6.2: Add API Makefile
+
+**Files:**
+- Create: `api/Makefile`
+
+- [ ] **Step 1: Create the file:**
+
+```makefile
+.PHONY: sync-content dev test build clean
+
+# Copy frontend content into embedded/ for go:embed.
+# Required before `go build` / `go run` / `go test` because go:embed needs
+# the referenced paths to exist at compile time.
+sync-content:
+	@rm -rf internal/chat/embedded
+	@mkdir -p internal/chat/embedded/projects
+	@cp ../frontend/src/content/resume/profile.md internal/chat/embedded/resume.md
+	@cp ../frontend/src/content/projects/*.md internal/chat/embedded/projects/
+	@echo "Content synced into internal/chat/embedded/"
+
+dev: sync-content
+	go run ./cmd/server
+
+test: sync-content
+	go test ./... -v
+
+build: sync-content
+	go build -o bin/server ./cmd/server
+
+clean:
+	@rm -rf internal/chat/embedded bin
+```
+
+- [ ] **Step 2: Run `make sync-content` and verify:**
+
+```bash
+cd api && make sync-content
+ls internal/chat/embedded/
+# Expected: resume.md (file), projects/ (directory with .md files)
+```
+
+- [ ] **Step 3: Commit:**
+
+```bash
+git add api/Makefile
+git commit -m "chore(p9): add API Makefile with sync-content target"
+```
+
+### Task 6.3: Refactor `context.go` — split persona/rules helpers (TDD)
+
+**Files:**
+- Modify: `api/internal/chat/context.go`
+- Create: `api/internal/chat/context_test.go`
+
+This refactor decomposes the monolithic `SystemPrompt()` string into helper functions, **before** introducing the embed step. This isolates the structural change from the content-source change.
+
+- [ ] **Step 1: Read existing `context.go`:**
+
+```bash
+cat api/internal/chat/context.go
+```
+
+- [ ] **Step 2: Write failing tests:**
+
+```go
+// api/internal/chat/context_test.go
+package chat
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSystemPromptIncludesPersona(t *testing.T) {
+	p := SystemPrompt()
+	if !strings.Contains(p, "Rafael Abreu's AI assistant") {
+		t.Error("SystemPrompt should include the persona marker phrase")
+	}
+}
+
+func TestSystemPromptIncludesRules(t *testing.T) {
+	p := SystemPrompt()
+	if !strings.Contains(p, "Only answer questions about Rafael") {
+		t.Error("SystemPrompt should include the rules marker phrase")
+	}
+}
+
+func TestSystemPromptStructure(t *testing.T) {
+	p := SystemPrompt()
+	personaIdx := strings.Index(p, "Rafael Abreu's AI assistant")
+	rulesIdx := strings.Index(p, "Only answer questions about Rafael")
+	if personaIdx == -1 || rulesIdx == -1 {
+		t.Fatal("required markers missing")
+	}
+	if !(personaIdx < rulesIdx) {
+		t.Error("persona block must precede rules block")
+	}
+}
+```
+
+- [ ] **Step 3: Run tests, expect PASS** (the existing `SystemPrompt()` already has both phrases):
+
+```bash
+cd api && go test ./internal/chat/ -v
+```
+
+Expected: 3 tests pass against the existing implementation.
+
+- [ ] **Step 4: Refactor `context.go` to extract helpers** (preserves the prompt content exactly, just splits the structure):
+
+```go
+package chat
+
+import "strings"
+
+func SystemPrompt() string {
+	var b strings.Builder
+	b.WriteString(personaBlock())
+	b.WriteString("\n\n")
+	b.WriteString(rulesBlock())
+	return b.String()
+}
+
+func personaBlock() string {
+	return `You are Rafael Abreu's AI assistant on his portfolio website. You answer questions about Rafael's professional background, skills, projects, and experience.
+
+ABOUT RAFAEL:
+- Software Engineer based in Toronto, Ontario, Canada
+- Full-stack developer with experience across technology, television, and education industries
+- Currently focused on Go, Python, and AI/ML engineering
+- Completed the University of Toronto Coding Bootcamp
+- Holds a Red Hat Kubernetes certificate (OpenShift training)
+
+TECHNICAL SKILLS:
+- Languages: Go, Python, JavaScript, TypeScript, HTML, CSS
+- Frameworks: React, Astro, Node.js, Tailwind CSS, Bootstrap
+- Infrastructure: Kubernetes, Docker, CI/CD, Netlify, Fly.io
+- AI & Data: LLM Integration, Gemini API, RAG, MongoDB, MySQL
+- Practices: TDD, OOP, MVC, System Design, Agile
+
+NOTABLE PROJECTS:
+- FPTV: Developed the website for a Toronto-based TV channel broadcasting across Canada. Features glassmorphism dashboard. (HTML, CSS, JavaScript, Weebly)
+- Freckles Design: Artist portfolio platform built in partnership with a fine artist. (React, Bootstrap, Netlify)
+- Charge It Up: EV charging station locator for North America. (HTML, CSS, Tailwind, JavaScript)
+- This portfolio itself: Astro frontend + Go API backend with AI chatbot, demonstrating modern architecture.`
+}
+
+func rulesBlock() string {
+	return `RULES:
+- Only answer questions about Rafael's professional background, skills, projects, and experience.
+- Be concise and helpful. Keep responses under 200 words.
+- If asked something unrelated to Rafael's professional life, politely redirect: "I'm here to help with questions about Rafael's experience and work. What would you like to know?"
+- Be friendly and professional in tone.
+- You may suggest that visitors check out specific projects or sections of the portfolio when relevant.`
+}
+```
+
+- [ ] **Step 5: Re-run tests, expect PASS:**
+
+```bash
+cd api && go test ./internal/chat/ -v
+```
+
+- [ ] **Step 6: Commit:**
+
+```bash
+git add api/internal/chat/context.go api/internal/chat/context_test.go
+git commit -m "refactor(p9): split SystemPrompt into persona and rules helpers
+
+No content change — the assembled string is byte-identical to the
+prior monolithic version. Sets up clean insertion points for the
+upcoming embedded-markdown integration."
+```
+
+### Task 6.4: Switch `context.go` to embedded markdown content (TDD)
+
+**Files:**
+- Modify: `api/internal/chat/context.go`
+- Modify: `api/internal/chat/context_test.go`
+
+- [ ] **Step 1: Add failing tests for the new behavior:**
+
+Append to `context_test.go`:
+
+```go
+func TestSystemPromptIncludesResumeContent(t *testing.T) {
+	p := SystemPrompt()
+	if !strings.Contains(p, "Rafael Abreu") {
+		t.Error("SystemPrompt should include resume content (e.g., the canonical name)")
+	}
+	if !strings.Contains(p, "## RESUME") {
+		t.Error("SystemPrompt should include the RESUME section header")
+	}
+}
+
+func TestSystemPromptIncludesAllProjects(t *testing.T) {
+	p := SystemPrompt()
+	if !strings.Contains(p, "## PROJECT CASE STUDIES") {
+		t.Error("SystemPrompt should include the PROJECT CASE STUDIES section header")
+	}
+	// Each project markdown's frontmatter title should appear.
+	// Read embedded directory to know the count.
+	entries, err := projectsFS.ReadDir("embedded/projects")
+	if err != nil {
+		t.Fatalf("failed to read embedded projects: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("no embedded projects found — sync step must run before tests")
+	}
+	// Spot-check: expect at least one project's content to be in the prompt.
+	for _, entry := range entries {
+		content, err := projectsFS.ReadFile("embedded/projects/" + entry.Name())
+		if err != nil {
+			t.Errorf("failed to read %s: %v", entry.Name(), err)
+			continue
+		}
+		// First 100 chars should appear if the file was concatenated.
+		snippet := string(content)
+		if len(snippet) > 100 {
+			snippet = snippet[:100]
+		}
+		if !strings.Contains(p, snippet) {
+			t.Errorf("project file %s content not found in SystemPrompt", entry.Name())
+		}
+	}
+}
+
+func TestSystemPromptOrderingResumeBeforeProjects(t *testing.T) {
+	p := SystemPrompt()
+	resumeIdx := strings.Index(p, "## RESUME")
+	projectsIdx := strings.Index(p, "## PROJECT CASE STUDIES")
+	if resumeIdx == -1 || projectsIdx == -1 {
+		t.Fatal("required section headers missing")
+	}
+	if !(resumeIdx < projectsIdx) {
+		t.Error("RESUME section must precede PROJECT CASE STUDIES")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests, expect FAIL** (the embed-based fields don't exist yet):
+
+```bash
+cd api && make sync-content && go test ./internal/chat/ -v
+```
+
+Expected: compilation error or test failures referencing `projectsFS`.
+
+- [ ] **Step 3: Update `context.go` to use embedded files:**
+
+```go
+package chat
+
+import (
+	"embed"
+	"io/fs"
+	"sort"
+	"strings"
+)
+
+//go:embed embedded/resume.md
+var resumeMD string
+
+//go:embed embedded/projects/*.md
+var projectsFS embed.FS
+
+func SystemPrompt() string {
+	var b strings.Builder
+	b.WriteString(personaBlock())
+	b.WriteString("\n\n## RESUME\n\n")
+	b.WriteString(resumeMD)
+	b.WriteString("\n\n## PROJECT CASE STUDIES\n\n")
+	b.WriteString(assembleProjects())
+	b.WriteString("\n\n")
+	b.WriteString(rulesBlock())
+	return b.String()
+}
+
+func assembleProjects() string {
+	entries, err := fs.ReadDir(projectsFS, "embedded/projects")
+	if err != nil {
+		return ""
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	var b strings.Builder
+	for _, entry := range entries {
+		content, err := fs.ReadFile(projectsFS, "embedded/projects/"+entry.Name())
+		if err != nil {
+			continue
+		}
+		b.Write(content)
+		b.WriteString("\n\n---\n\n")
+	}
+	return b.String()
+}
+
+func personaBlock() string {
+	// Persona is generic — Rafael's specific bio/skills now come from resume.md.
+	return `You are Rafael Abreu's AI assistant on his portfolio website. You answer questions about Rafael's professional background, skills, projects, and experience.
+
+The sections below contain Rafael's current resume and project case studies. Use them as your primary source of truth. The information here is authoritative; ignore any prior knowledge that conflicts.`
+}
+
+func rulesBlock() string {
+	return `RULES:
+- Only answer questions about Rafael's professional background, skills, projects, and experience.
+- Be concise and helpful. Keep responses under 200 words.
+- If asked something unrelated to Rafael's professional life, politely redirect: "I'm here to help with questions about Rafael's experience and work. What would you like to know?"
+- Be friendly and professional in tone.
+- You may suggest that visitors check out specific projects or sections of the portfolio when relevant.`
+}
+```
+
+- [ ] **Step 4: Run tests, expect PASS:**
+
+```bash
+cd api && make test
+```
+
+- [ ] **Step 5: Commit:**
+
+```bash
+git add api/internal/chat/context.go api/internal/chat/context_test.go
+git commit -m "feat(p9): replace hardcoded SystemPrompt content with embedded markdown
+
+context.go now embeds frontend/src/content/resume/profile.md and
+frontend/src/content/projects/*.md (copied via make sync-content) and
+assembles them into the system prompt at startup. The prior bio/skills/
+projects block in personaBlock() is removed in favor of the resume —
+single source of truth."
+```
+
+### Task 6.5: Update API deploy workflow
+
+**Files:**
+- Modify: `.github/workflows/deploy-api.yml`
+
+- [ ] **Step 1: Replace the file contents:**
+
+```yaml
+name: Deploy API
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'api/**'
+      - 'frontend/src/content/resume/**'
+      - 'frontend/src/content/projects/**'
+
+jobs:
+  deploy:
+    name: Deploy to Fly.io
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: api
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Sync content for embedding
+        run: make sync-content
+
+      - name: Run tests
+        run: go test ./... -v
+
+      - name: Set up Fly CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+```
+
+Note the additional `paths:` triggers — when `frontend/src/content/resume/**` or `frontend/src/content/projects/**` change on `main`, the API redeploys so the chatbot picks up new content.
+
+- [ ] **Step 2: Commit:**
+
+```bash
+git add .github/workflows/deploy-api.yml
+git commit -m "ci(p9): sync content before API build; trigger on resume/project changes"
+```
+
+---
+
+## Phase 7: E2E Tests, Roadmap, README
+
+### Task 7.1: E2E Playwright test for the modal flow
+
+**Files:**
+- Create: `frontend/playwright.config.ts`
+- Create: `frontend/tests/e2e/resume.spec.ts`
+- Modify: `frontend/package.json`
+
+- [ ] **Step 1: Create `frontend/playwright.config.ts`:**
+
+```typescript
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  webServer: {
+    command: 'npm run preview',
+    url: 'http://localhost:4321',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+  use: {
+    baseURL: 'http://localhost:4321',
+  },
+});
+```
+
+- [ ] **Step 2: Install Playwright test runner:**
+
+```bash
+cd frontend && npm install --save-dev @playwright/test
+```
+
+- [ ] **Step 3: Create `frontend/tests/e2e/resume.spec.ts`:**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('Resume button in nav opens the modal with expected content', async ({ page }) => {
+  await page.goto('/');
+  await page.locator('a:has-text("RESUME")').first().click();
+
+  const dialog = page.locator('dialog#resume-modal');
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator('.name')).toBeVisible();
+  await expect(dialog.locator('text=Download PDF')).toBeVisible();
+  await expect(dialog.locator('text=LinkedIn')).toBeVisible();
+});
+
+test('Download PDF link points to the static PDF asset', async ({ page }) => {
+  await page.goto('/');
+  await page.locator('a:has-text("RESUME")').first().click();
+  const downloadHref = await page.locator('.btn-download').getAttribute('href');
+  expect(downloadHref).toBe('/Rafael_Abreu_Resume.pdf');
+});
+
+test('Resume button is hidden on /resume page', async ({ page }) => {
+  await page.goto('/resume');
+  await expect(page.locator('a:has-text("RESUME")')).toHaveCount(0);
+});
+
+test('/resume page renders resume content directly', async ({ page }) => {
+  await page.goto('/resume');
+  await expect(page.locator('h1.resume-page-name')).toBeVisible();
+});
+```
+
+- [ ] **Step 4: Add `test:e2e` script to `package.json`:**
+
+```json
+"test:e2e": "playwright test"
+```
+
+- [ ] **Step 5: Run the E2E test against the built site:**
+
+```bash
+cd frontend
+npm run build
+npm run build:pdf
+npm run test:e2e
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 6: Commit:**
+
+```bash
+git add frontend/playwright.config.ts frontend/tests/e2e/resume.spec.ts frontend/package.json frontend/package-lock.json
+git commit -m "test(p9): add E2E coverage for resume modal and /resume page"
+```
+
+### Task 7.2: Update phase 2 roadmap
+
+**Files:**
+- Modify: `docs/phase2-roadmap.md`
+
+- [ ] **Step 1: Read current roadmap to find P8 entry:**
+
+```bash
+cat docs/phase2-roadmap.md | tail -40
+```
+
+- [ ] **Step 2: Append the P9 entry** before the "Dependency Map" section:
+
+```markdown
+### ~~P9: Resume Feature~~ ✅ Done (PR #__)
+
+**What:** A markdown-driven resume rendered as an in-site modal, downloadable PDF, and chatbot grounding source — replacing the previously broken Resume button.
+
+**Why:** The Resume button on the portfolio was a 404. Rather than dropping a static PDF that goes stale, this establishes a single-source-of-truth model: edit one markdown file, three artifacts (modal, PDF, chatbot prompt) regenerate deterministically. Also fixes a latent staleness bug where the chatbot's project knowledge drifted from the actual portfolio.
+
+**Scope:**
+- New Astro content collection at `frontend/src/content/resume/profile.md` with full Zod schema
+- 9 section components rendering structured data into HTML
+- ResumeModal using the native `<dialog>` element (no React island)
+- /resume standalone page (also serves as Playwright's PDF print source)
+- Build-time PDF generation via Playwright in CI
+- Chatbot system prompt assembled from resume + project markdown via `go:embed`
+- E2E coverage for the modal flow
+
+**Estimated effort:** 1-2 sessions
+
+**Out of scope (deferred):** AI-driven LinkedIn ingestion, GitHub-based skill auto-extraction, AI-generated bullets. Considered during brainstorming and rejected as overkill for an artifact that changes 4–6 times per year.
+
+---
+```
+
+Also update the Dependency Map block to include P9:
+
+```
+P9 (Resume Feature)    — independent, replaces broken Resume button
+```
+
+- [ ] **Step 3: Commit:**
+
+```bash
+git add docs/phase2-roadmap.md
+git commit -m "docs(p9): add P9 resume feature entry to phase 2 roadmap"
+```
+
+### Task 7.3: Update root `CLAUDE.md` with first-time-clone note
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add a sentence to the API "Build & Run" block** in `CLAUDE.md`:
+
+Find the section that reads:
+````
+### API (Go)
+```bash
+cd api
+go run ./cmd/server  # dev server on :8080
+go test ./... -v     # run tests
+go vet ./...         # lint
+go build ./cmd/server
+```
+Requires: Go 1.26+
+````
+
+Insert a note after the code block:
+
+```markdown
+**First-time clone:** run `make sync-content` (or `make dev`) before any `go` command — `internal/chat/embedded/` is gitignored and populated from `frontend/src/content/` at build time. `make dev` and `make test` invoke `sync-content` automatically.
+```
+
+- [ ] **Step 2: Commit:**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(p9): document first-time-clone setup for embedded chat content"
+```
+
+### Task 7.4: Final smoke test — full stack runs locally
+
+**Files:** none modified.
+
+- [ ] **Step 1: Frontend build pipeline succeeds end-to-end:**
+
+```bash
+cd frontend
+npm ci
+npm run build
+npm run build:pdf
+ls -la dist/Rafael_Abreu_Resume.pdf
+```
+
+Expected: PDF exists, > 10KB.
+
+- [ ] **Step 2: API builds and tests pass with embedded content:**
+
+```bash
+cd ../api
+make sync-content
+make test
+make build
+```
+
+Expected: tests green, binary built.
+
+- [ ] **Step 3: Run the full app locally and verify chatbot picks up new content:**
+
+In one terminal:
+
+```bash
+cd api && make dev
+```
+
+In another:
+
+```bash
+cd frontend && npm run dev
+```
+
+Open `http://localhost:4321/`:
+- Click RESUME → modal opens with the resume content from `profile.md`
+- Click Download PDF → PDF downloads (will only work after `npm run build && npm run build:pdf`)
+- Open the chat widget → ask "What is Rafael's most recent role?" → response should reflect content from `profile.md`
+
+- [ ] **Step 4: Stop both servers.** No commit needed (no files changed).
+
+### Task 7.5: Open the pull request
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch:**
+
+```bash
+git push -u origin feature/resume
+```
+
+(Per the project's no-push-without-consent rule, only do this step when the user has explicitly asked to push.)
+
+- [ ] **Step 2: Open the PR:**
+
+```bash
+gh pr create --title "feat(p9): resume feature — modal, PDF, chatbot grounding" --body "$(cat <<'EOF'
+## Summary
+
+Implements P9 per spec `docs/superpowers/specs/2026-04-30-resume-feature-design.md`. Closes #25.
+
+- **Single source of truth:** `frontend/src/content/resume/profile.md`
+- **In-site modal:** native `<dialog>`, no React hydration
+- **Build-time PDF:** Playwright in CI, `frontend/dist/Rafael_Abreu_Resume.pdf`
+- **Chatbot grounding:** `SystemPrompt()` now embeds resume + project markdown via `go:embed`
+
+## Test plan
+- [ ] CI green
+- [ ] Visit `https://<deploy-preview>/` → click RESUME → modal renders correctly in dark and light themes
+- [ ] Click "Download PDF" → file downloads, opens cleanly
+- [ ] Visit `https://<deploy-preview>/resume` directly → page renders, RESUME nav button hidden
+- [ ] Open chat widget → ask about a recent role → response reflects new content
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3:** Return the PR URL to the user.
+
+---
+
+## Self-Review Checklist (run after writing the plan)
+
+**Spec coverage:**
+- ✅ Schema (Task 1.1) covers every field in the spec's data model
+- ✅ All 9 section components (Tasks 2.2–2.8) match the spec's component table
+- ✅ ResumeBody assembler (Task 3.1) and standalone page (Task 3.2)
+- ✅ Modal (Task 4.1) with event delegation per spec
+- ✅ BaseLayout opt-out prop (Task 4.2)
+- ✅ Nav and MobileNav conditional hiding (Tasks 4.3, 4.4)
+- ✅ PDF generator with random port (Task 5.2)
+- ✅ Frontend CI updates (Task 5.3)
+- ✅ Chatbot embedding refactor in two steps — structural split first (Task 6.3), content swap second (Task 6.4)
+- ✅ API gitignore + Makefile (Tasks 6.1, 6.2)
+- ✅ API CI updates with content sync + path triggers (Task 6.5)
+- ✅ E2E tests (Task 7.1)
+- ✅ Roadmap and CLAUDE.md updates (Tasks 7.2, 7.3)
+- ✅ Final smoke test (Task 7.4)
+- ✅ PR opening (Task 7.5)
+
+**Placeholder scan:** No "TBD"/"TODO"/"implement later" — every step has concrete code or commands.
+
+**Type/path consistency:**
+- `resume` collection always referenced as `'resume'` and entry `'profile'`
+- Path `frontend/src/content/resume/profile.md` consistent
+- `data-resume-trigger` attribute used identically in modal script, Nav, MobileNav
+- `includeResumeModal` prop used identically in BaseLayout and resume.astro
+- `assembleProjects()` and `projectsFS` referenced consistently
+- The MobileNav prop change (`resumePath` → `isResumePage`) is reflected in both the Nav.astro caller and the MobileNav.tsx interface
+
+**Notes for executor:**
+- The plan assumes the executor has the LinkedIn export accessible at `/Users/rafaeldeabreugomes/Downloads/rafael_abreu_linkedin_profile.md`. If running on a different machine, the user must provide their own equivalent.
+- The plan does **not** push to `main` or open the PR without explicit user consent (per project safety rules). Only the local branch commits run automatically.

--- a/docs/superpowers/specs/2026-04-30-resume-feature-design.md
+++ b/docs/superpowers/specs/2026-04-30-resume-feature-design.md
@@ -163,6 +163,8 @@ Pure Astro component using the native HTML `<dialog>` element. No React island. 
 
 The modal is included site-wide via `BaseLayout.astro`, **except on the `/resume` route** (which already renders the same content inline). The layout accepts an `includeResumeModal` prop that defaults to `true`; `resume.astro` sets it to `false`. Triggers across the site (Nav, MobileNav, hero CTA if added later) all use the `data-resume-trigger` attribute. Event delegation means the React-hydrated MobileNav button works the same as the static Astro Nav anchor — both add `data-resume-trigger` to their rendered button element.
 
+Because the modal isn't on `/resume`, the Resume button in Nav and MobileNav must also be suppressed there — clicking a `data-resume-trigger` element on `/resume` would be a no-op without the modal listener installed. Both `Nav.astro` and `MobileNav.tsx` accept the current pathname (via `Astro.url.pathname` for the former, a prop for the latter) and conditionally hide the Resume button when `pathname === '/resume'`. The Nav remains otherwise unchanged — visitors on the resume page have already arrived at the destination the button would have taken them to.
+
 ### Print Page — `frontend/src/pages/resume.astro`
 
 Standalone full-page route, A4 layout, print-stylesheet-aware. Same data as the modal, different shell. Two purposes:
@@ -200,11 +202,13 @@ import { createServer } from 'http';
 import handler from 'serve-handler';
 
 const server = createServer((req, res) => handler(req, res, { public: 'dist' }));
-await new Promise((r) => server.listen(4321, r));
+// Port 0 = OS-assigned free port. Avoids collision with Astro's default dev port (4321).
+await new Promise((resolve) => server.listen(0, resolve));
+const { port } = server.address();
 
 const browser = await chromium.launch();
 const page = await browser.newPage();
-await page.goto('http://localhost:4321/resume', { waitUntil: 'networkidle' });
+await page.goto(`http://localhost:${port}/resume`, { waitUntil: 'load' });
 await page.emulateMedia({ media: 'print' });
 await page.pdf({
   path: 'dist/Rafael_Abreu_Resume.pdf',
@@ -322,7 +326,7 @@ Both deploys complete within a few minutes of the push. Eventually consistent �
 | `embedded/` empty at API build | `go:embed` fails compile | Don't ship API with empty grounding |
 | Modal runtime exception | Native `<dialog>` is bulletproof — closes via ESC/click-outside regardless | No JS framework runtime to fail |
 | Resume PDF URL 404 in browser | Cannot happen post-fix; PDF is rebuilt every deploy | Fixes the existing bug |
-| Project markdown referenced by `selected_projects` slug doesn't exist | Build-time warning logged; entry rendered without link | Soft fail — better to ship a slightly-degraded resume than break the build over a typo |
+| Project markdown referenced by `selected_projects` slug doesn't exist | Build fails with a Zod error pointing at the bad slug | Hard fail via `reference('projects')` — consistent with the 100%-accuracy stance; a typo silently rendering a broken link is worse than a build break that takes ten seconds to fix |
 
 The pattern: **fail loudly at build time, silently never at runtime.** Bad data never reaches users.
 
@@ -368,9 +372,9 @@ Frontend job + API job + new E2E job all green before merge. PR cannot merge wit
 | `frontend/src/components/resume/Projects.astro` | New — section component |
 | `frontend/src/components/resume/ResumeBody.astro` | New — assembles all section components |
 | `frontend/src/pages/resume.astro` | New — print-styled standalone page |
-| `frontend/src/layouts/BaseLayout.astro` | Include `<ResumeModal />` once site-wide |
-| `frontend/src/components/Nav.astro` | Resume button → `data-resume-trigger`, no longer href to PDF |
-| `frontend/src/islands/MobileNav.tsx` | Resume button → trigger modal via shared event |
+| `frontend/src/layouts/BaseLayout.astro` | Include `<ResumeModal />` once site-wide; accept `includeResumeModal` prop (defaults `true`) for opt-out on `/resume` |
+| `frontend/src/components/Nav.astro` | Resume button → `data-resume-trigger`, no longer href to PDF; conditionally hidden when `Astro.url.pathname === '/resume'` |
+| `frontend/src/islands/MobileNav.tsx` | Resume button → `data-resume-trigger`; receives current pathname as prop, conditionally hidden on `/resume` |
 | `frontend/src/styles/global.css` | Add resume modal + print styles, theme-token-aware |
 | `frontend/scripts/generate-pdf.mjs` | New — Playwright PDF generator |
 | `frontend/package.json` | Add `playwright` and `serve-handler` as devDependencies |

--- a/docs/superpowers/specs/2026-04-30-resume-feature-design.md
+++ b/docs/superpowers/specs/2026-04-30-resume-feature-design.md
@@ -1,0 +1,403 @@
+# P9: Resume Feature — Design Spec
+
+> Replaces the currently broken Resume button (404 on `/Rafael_Abreu_Resume.pdf`) with a hand-edited markdown source rendered to a styled in-site modal, a downloadable PDF generated at build time, and a chatbot system prompt assembled from the same source plus the existing project case studies.
+
+## Overview
+
+The portfolio's Resume button currently 404s — no PDF exists in `frontend/public/`. Rather than dropping a static PDF file, this feature establishes a sustainable single-source-of-truth model: Rafael edits one markdown file, and the site renders three artifacts from it (modal, PDF, chatbot context).
+
+The feature explicitly avoids the AI-driven pipeline considered during brainstorming (LinkedIn ingestion, GitHub-derived skill extraction, AI-generated bullets, accuracy validators). For an artifact that changes 4–6 times per year, that pipeline's maintenance cost outweighed its value. The simple version captures ~95% of the value with ~5% of the moving parts.
+
+## Architecture
+
+```
+                ┌──────────────────────────────────────────┐
+                │  frontend/src/content/resume/profile.md  │  ← single source of truth
+                └──────────────────┬───────────────────────┘
+                                   │
+        ┌──────────────────────────┼──────────────────────────┐
+        │                          │                          │
+        ▼                          ▼                          ▼
+   Astro build              Playwright (CI)             CI sync step
+   (modal + page)           PDF generation              (copies markdown)
+        │                          │                          │
+        ▼                          ▼                          ▼
+   ResumeModal.astro       Rafael_Abreu_              api/internal/chat/
+   + /resume page          Resume.pdf                 embedded/
+                           (frontend/dist)            ↓
+                                                Go embed → SystemPrompt()
+                                                (resume + projects + persona)
+```
+
+Three render targets, one source. All rendering is deterministic at build time; no AI in the request path. The chatbot is grounded in both the resume and the existing project case studies (`frontend/src/content/projects/*.md`), fixing a latent staleness bug where the current hardcoded `SystemPrompt()` drifts from the actual portfolio.
+
+## Data Model
+
+The resume lives at `frontend/src/content/resume/profile.md` inside a new Astro content collection. The frontmatter carries all structured data; the markdown body is reserved for free-form narrative, expected to remain empty in practice.
+
+```yaml
+---
+name: "Rafael Abreu"
+title: "Software Engineer | Engineering Leadership Track"
+location: "Toronto, ON, Canada"
+
+links:
+  linkedin:  "https://www.linkedin.com/in/rafael-abreu"
+  github:    "https://github.com/rfabreu"
+  portfolio: "https://rafaelabreu.netlify.app"
+
+summary: |
+  One-paragraph executive-positioned summary. Roughly three sentences:
+  who you are, what you've delivered, where you're heading.
+
+work_history:
+  - company:    "Nextologies"
+    title:      "Software Engineer"
+    dates:      "2023 — Present"
+    location:   "Toronto, ON"
+    tech_stack: ["Go", "Python", "Kubernetes", "Docker", "AWS"]
+    bullets:
+      - "Architected ..."
+      - "Drove ..."
+
+education:
+  - school:  "University of Toronto"
+    program: "Coding Bootcamp — Full-Stack Web Development"
+    dates:   "2022 — 2023"
+
+certifications:
+  - name:   "Red Hat Certified Specialist in OpenShift Administration"
+    issuer: "Red Hat"
+    year:   "2024"
+
+skills:
+  leadership:
+    - "Strategic Planning"
+    - "Cross-functional Stakeholder Management"
+    - "Hiring & Team Building"
+  technical:
+    - "Go, Python, TypeScript"
+    - "Kubernetes, Docker, CI/CD"
+    - "AI/ML Integration (Gemini, RAG)"
+  domain:
+    - "Broadcast / Live TV Operations"
+    - "EdTech"
+
+awards_recognition: []      # optional, fills over time
+speaking_writing:   []      # optional, fills over time
+
+languages_spoken:
+  - "English (Native)"
+  - "Portuguese (Native)"
+
+selected_projects:
+  - slug:     "fptv"        # references frontend/src/content/projects/fptv.md
+    headline: "Glassmorphism dashboard for Toronto-based TV broadcaster"
+  - slug:     "portfolio"
+    headline: "Astro + Go monorepo with AI chatbot and game"
+---
+```
+
+### Schema Validation
+
+`frontend/src/content.config.ts` defines a Zod schema for the `resume` collection. Required fields: `name`, `title`, `location`, `links.linkedin`, `summary`, `work_history`, `education`, `skills`. Optional fields: `certifications`, `awards_recognition`, `speaking_writing`, `languages_spoken`, `selected_projects`. The `bullets` field on each `work_history` entry defaults to an empty array, allowing a job to be added before bullets are written. Invalid frontmatter fails the build with a useful error pointing at the offending field.
+
+`selected_projects[].slug` uses Astro's `reference('projects')` Zod helper to validate at build time that the referenced slug exists in the `projects` collection. A typo or stale reference fails the build immediately, rather than silently rendering a broken link at runtime.
+
+### Design Decisions
+
+- **No phone or email in the schema.** Per the project's no-direct-contact-channel policy. Rendered footer in modal and PDF reads: *"Contact via the form on rafaelabreu.netlify.app or LinkedIn"*.
+- **Skills are bucketed by category** (`leadership` / `technical` / `domain`) so the renderer can group without inference.
+- **No skill levels** (`level: senior`). Modern senior resumes don't use them.
+- **`selected_projects` references existing project slugs** rather than duplicating content. The renderer looks up the corresponding case study and links to it.
+- **Freeform `dates` strings** ("2023 — Present"). Sortability isn't needed for ~5 jobs ever; structured dates would be friction without payoff.
+- **`awards_recognition` and `speaking_writing` start empty.** Optional sections render nothing when empty. Strong exec-track resumes accumulate entries here over time; having the structure ready means there's no friction when content arrives.
+- **`tech_stack` per work entry** keeps bullets outcome-focused. The renderer shows the stack as small tags below each role's bullets.
+
+## Components
+
+### Modal — `frontend/src/components/ResumeModal.astro`
+
+Pure Astro component using the native HTML `<dialog>` element. No React island. The modal has only open/close behavior — that's all native to `<dialog>` (ESC handling, focus trap, click-outside via the `::backdrop` pseudo-element). Eliminates a hydrating bundle.
+
+```astro
+<dialog id="resume-modal" class="resume-modal">
+  <header class="resume-modal-header">
+    <div class="resume-modal-title">
+      <span class="name">{resume.name}</span>
+      <span class="title">{resume.title}</span>
+    </div>
+    <div class="resume-modal-actions">
+      <a href="/Rafael_Abreu_Resume.pdf" download class="btn-download">Download PDF</a>
+      <button type="button" class="btn-close" aria-label="Close">×</button>
+    </div>
+  </header>
+  <div class="resume-modal-body">
+    <ResumeBody resume={resume} />
+  </div>
+  <footer class="resume-modal-footer">
+    <span>Contact via <a href="/#contact">contact form</a> or
+    <a href={resume.links.linkedin}>LinkedIn →</a></span>
+  </footer>
+</dialog>
+
+<script>
+  const modal = document.getElementById('resume-modal') as HTMLDialogElement | null;
+
+  // Event delegation — works for static Astro triggers AND React-hydrated triggers
+  // (MobileNav button is rendered after page load, so per-element binding would miss it).
+  document.addEventListener('click', (e) => {
+    const trigger = (e.target as HTMLElement)?.closest('[data-resume-trigger]');
+    if (trigger) {
+      e.preventDefault();
+      modal?.showModal();
+    }
+  });
+
+  modal?.querySelector('.btn-close')?.addEventListener('click', () => modal.close());
+  modal?.addEventListener('click', (e) => {
+    if (e.target === modal) modal.close();
+  });
+</script>
+```
+
+The modal is included site-wide via `BaseLayout.astro`, **except on the `/resume` route** (which already renders the same content inline). The layout accepts an `includeResumeModal` prop that defaults to `true`; `resume.astro` sets it to `false`. Triggers across the site (Nav, MobileNav, hero CTA if added later) all use the `data-resume-trigger` attribute. Event delegation means the React-hydrated MobileNav button works the same as the static Astro Nav anchor — both add `data-resume-trigger` to their rendered button element.
+
+### Print Page — `frontend/src/pages/resume.astro`
+
+Standalone full-page route, A4 layout, print-stylesheet-aware. Same data as the modal, different shell. Two purposes:
+
+1. Playwright loads `http://localhost:<port>/resume` during CI to print the PDF.
+2. Anyone with the URL can view the resume directly without going through the home page.
+
+Uses the `BaseLayout` shell with a `print-mode` class that suppresses nav/footer in `@media print` and forces the PDF-friendly typography.
+
+### Shared Section Components — `frontend/src/components/resume/`
+
+Each frontmatter section has its own Astro component. Both `ResumeModal.astro` and `resume.astro` import these via a `<ResumeBody />` wrapper:
+
+| Component | Renders |
+|-----------|---------|
+| `Summary.astro` | `summary` paragraph |
+| `Skills.astro` | `skills` grouped by category |
+| `WorkHistory.astro` | `work_history` entries with bullets and `tech_stack` tags |
+| `Education.astro` | `education` entries |
+| `Certifications.astro` | `certifications` list |
+| `Awards.astro` | `awards_recognition` (skipped if empty) |
+| `Speaking.astro` | `speaking_writing` (skipped if empty) |
+| `Languages.astro` | `languages_spoken` list |
+| `Projects.astro` | `selected_projects` with slug-resolved links to case studies |
+
+Single source of layout per section, two render contexts. Empty optional sections render nothing — no visual penalty for blanks.
+
+### PDF Generator — `frontend/scripts/generate-pdf.mjs`
+
+Node script using Playwright. Runs in CI after `npm run build`:
+
+```javascript
+import { chromium } from 'playwright';
+import { createServer } from 'http';
+import handler from 'serve-handler';
+
+const server = createServer((req, res) => handler(req, res, { public: 'dist' }));
+await new Promise((r) => server.listen(4321, r));
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+await page.goto('http://localhost:4321/resume', { waitUntil: 'networkidle' });
+await page.emulateMedia({ media: 'print' });
+await page.pdf({
+  path: 'dist/Rafael_Abreu_Resume.pdf',
+  format: 'A4',
+  printBackground: true,
+  margin: { top: '0.5in', right: '0.5in', bottom: '0.5in', left: '0.5in' },
+});
+
+await browser.close();
+server.close();
+```
+
+The PDF is written into `frontend/dist/`, which Netlify deploys. Resume button (already pointing at `/Rafael_Abreu_Resume.pdf`) starts working without a code change.
+
+### Chatbot Integration — `api/internal/chat/`
+
+Replace the hardcoded content in `SystemPrompt()` with embedded markdown files plus a hardcoded persona/rules block.
+
+**New directory:** `api/internal/chat/embedded/` (gitignored, populated by CI).
+
+**Modified `context.go`:**
+
+```go
+package chat
+
+import (
+    "embed"
+    "fmt"
+    "io/fs"
+    "sort"
+    "strings"
+)
+
+//go:embed embedded/resume.md
+var resumeMD string
+
+//go:embed embedded/projects/*.md
+var projectsFS embed.FS
+
+func SystemPrompt() string {
+    var b strings.Builder
+    b.WriteString(personaBlock())
+    b.WriteString("\n\n## RESUME\n\n")
+    b.WriteString(resumeMD)
+    b.WriteString("\n\n## PROJECT CASE STUDIES\n\n")
+    b.WriteString(assembleProjects())
+    b.WriteString("\n\n")
+    b.WriteString(rulesBlock())
+    return b.String()
+}
+
+func assembleProjects() string {
+    entries, _ := fs.ReadDir(projectsFS, "embedded/projects")
+    sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+    var b strings.Builder
+    for _, entry := range entries {
+        content, err := fs.ReadFile(projectsFS, fmt.Sprintf("embedded/projects/%s", entry.Name()))
+        if err != nil { continue }
+        b.WriteString(string(content))
+        b.WriteString("\n\n---\n\n")
+    }
+    return b.String()
+}
+```
+
+`personaBlock()` and `rulesBlock()` hold the existing "You are Rafael Abreu's AI assistant…" and "Only answer questions about Rafael, be concise…" content respectively, lifted out of the current monolithic string.
+
+**CI sync step** (in `deploy-api.yml`, before `go build`):
+
+```yaml
+- name: Sync content for embedding
+  run: |
+    rm -rf api/internal/chat/embedded
+    mkdir -p api/internal/chat/embedded/projects
+    cp frontend/src/content/resume/profile.md api/internal/chat/embedded/resume.md
+    cp frontend/src/content/projects/*.md api/internal/chat/embedded/projects/
+```
+
+**Local dev:** new `api/Makefile` target `sync-content` runs the same copy. `make dev` runs `sync-content && go run ./cmd/server`.
+
+**First-time clone:** because `api/internal/chat/embedded/` is gitignored, a fresh clone won't compile the API until `make sync-content` (or `make dev`) runs once — `go:embed` requires the referenced paths to exist. README and `api/Makefile` should both document this. Alternative considered: commit the `embedded/` directory. Rejected because (a) it duplicates content already version-controlled in `frontend/`, and (b) it creates merge-conflict noise on every resume edit.
+
+## Data Flow
+
+```
+Edit profile.md
+       │
+       ▼
+push → feature branch → PR → review → merge to main
+       │
+       ├── deploy-frontend.yml
+       │     ├── npm ci
+       │     ├── npm run build
+       │     ├── npx playwright install chromium
+       │     ├── node scripts/generate-pdf.mjs   (writes dist/Rafael_Abreu_Resume.pdf)
+       │     └── netlify deploy
+       │
+       └── deploy-api.yml
+             ├── sync embedded markdown
+             ├── go vet ./...
+             ├── go test ./...
+             ├── go build
+             └── flyctl deploy
+```
+
+Both deploys complete within a few minutes of the push. Eventually consistent — there's a brief window where the frontend is live with new resume content but the API still has the old prompt. Acceptable for this surface (chatbot will catch up, no user-facing inconsistency).
+
+## Error Handling
+
+| Failure point | Behavior | Reasoning |
+|---|---|---|
+| Malformed `profile.md` frontmatter | Astro build fails with Zod error | Don't deploy a broken resume |
+| Missing required field | Build fails with field path | Same |
+| Playwright PDF generation fails | Frontend deploy fails | Don't ship the site without a working PDF — keeps the Resume button reliable |
+| `embedded/` empty at API build | `go:embed` fails compile | Don't ship API with empty grounding |
+| Modal runtime exception | Native `<dialog>` is bulletproof — closes via ESC/click-outside regardless | No JS framework runtime to fail |
+| Resume PDF URL 404 in browser | Cannot happen post-fix; PDF is rebuilt every deploy | Fixes the existing bug |
+| Project markdown referenced by `selected_projects` slug doesn't exist | Build-time warning logged; entry rendered without link | Soft fail — better to ship a slightly-degraded resume than break the build over a typo |
+
+The pattern: **fail loudly at build time, silently never at runtime.** Bad data never reaches users.
+
+## Testing
+
+### Frontend
+
+- **Schema validation:** Zod schema in `content.config.ts` validates `profile.md` on every build. Build is the test.
+- **Snapshot tests:** rendered HTML for `ResumeModal.astro` and `/resume` page. Catches layout regressions.
+- **E2E (Playwright, new):** click Resume nav button → modal opens → expected text present → "Download PDF" link resolves to `/Rafael_Abreu_Resume.pdf`.
+
+### PDF
+
+- **Build assertion:** `frontend/dist/Rafael_Abreu_Resume.pdf` exists, size > 10KB after `generate-pdf.mjs`.
+- **Manual visual check** on first build. No automated visual regression — overkill for a single PDF rendered from a deterministic source.
+
+### API
+
+- Existing chat tests continue to pass.
+- **New: `TestSystemPromptIncludesResumeContent`** — assembled prompt contains a known string from `profile.md` (e.g., the canonical name).
+- **New: `TestSystemPromptIncludesAllProjects`** — for each file in `embedded/projects/`, assert its content appears in the prompt.
+- **New: `TestSystemPromptStructure`** — assert persona block precedes resume, resume precedes projects, rules block is last.
+
+### CI Gate
+
+Frontend job + API job + new E2E job all green before merge. PR cannot merge with any failing.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/src/content/resume/profile.md` | New — single source of truth |
+| `frontend/src/content.config.ts` | Add `resume` collection with Zod schema |
+| `frontend/src/components/ResumeModal.astro` | New — `<dialog>`-based modal |
+| `frontend/src/components/resume/Summary.astro` | New — section component |
+| `frontend/src/components/resume/Skills.astro` | New — section component |
+| `frontend/src/components/resume/WorkHistory.astro` | New — section component |
+| `frontend/src/components/resume/Education.astro` | New — section component |
+| `frontend/src/components/resume/Certifications.astro` | New — section component |
+| `frontend/src/components/resume/Awards.astro` | New — section component |
+| `frontend/src/components/resume/Speaking.astro` | New — section component |
+| `frontend/src/components/resume/Languages.astro` | New — section component |
+| `frontend/src/components/resume/Projects.astro` | New — section component |
+| `frontend/src/components/resume/ResumeBody.astro` | New — assembles all section components |
+| `frontend/src/pages/resume.astro` | New — print-styled standalone page |
+| `frontend/src/layouts/BaseLayout.astro` | Include `<ResumeModal />` once site-wide |
+| `frontend/src/components/Nav.astro` | Resume button → `data-resume-trigger`, no longer href to PDF |
+| `frontend/src/islands/MobileNav.tsx` | Resume button → trigger modal via shared event |
+| `frontend/src/styles/global.css` | Add resume modal + print styles, theme-token-aware |
+| `frontend/scripts/generate-pdf.mjs` | New — Playwright PDF generator |
+| `frontend/package.json` | Add `playwright` and `serve-handler` as devDependencies |
+| `frontend/tests/resume.spec.ts` | New — Playwright E2E: nav click → modal opens → expected text → PDF link resolves |
+| `frontend/tests/__snapshots__/resume-modal.snap` | New — snapshot for `ResumeModal.astro` rendered HTML |
+| `frontend/tests/__snapshots__/resume-page.snap` | New — snapshot for `/resume` page rendered HTML |
+| `api/internal/chat/context.go` | Refactor — split into persona/resume/projects/rules; use `go:embed` |
+| `api/internal/chat/context_test.go` | New tests — `TestSystemPromptIncludesResumeContent`, `TestSystemPromptIncludesAllProjects`, `TestSystemPromptStructure` |
+| `api/internal/chat/embedded/` | New gitignored directory; populated by CI sync |
+| `api/Makefile` | New — `sync-content` and `dev` targets |
+| `api/.gitignore` | Add `internal/chat/embedded/` |
+| `.github/workflows/deploy-frontend.yml` | Add Playwright install + PDF generation step |
+| `.github/workflows/deploy-api.yml` | Add content sync step before `go build` |
+| `.github/workflows/ci.yml` | Add resume schema validation + E2E job |
+| `docs/phase2-roadmap.md` | Add P9: Resume Feature entry |
+
+## Out of Scope
+
+The following were considered during brainstorming and explicitly excluded:
+
+- **AI-driven resume generation pipeline** — LinkedIn ingestion, GitHub-derived skill extraction, AI-generated bullets, accuracy validators, PR-bot suggestions. The maintenance and noise outweigh the benefit at portfolio scale (resumes change 4–6 times/year). Reconsider only if manual updating becomes a friction point.
+- **LinkedIn API integration** — official API requires Partner approval; scrapers violate ToS or break on layout changes. The realistic path (LinkedIn data export, manually refreshed) was not worth the ingestion plumbing for this version.
+- **Auto-update from GitHub webhooks or portfolio commits** — same reasoning. New repos rarely warrant resume changes.
+- **A separate AI editor / "rephrase this bullet" tool** — Rafael uses any LLM externally when editing the markdown. Not a build-pipeline feature.
+- **Phone or email on the resume** — per the no-direct-contact-channel policy. Contact form + LinkedIn cover all reach-out paths.
+- **Photo / avatar** — North American convention; introduces bias risk.
+- **Skill levels (`level: senior`)** — modern senior resumes don't use them.
+- **Multi-variant resumes** (e.g., backend-focused vs full-stack) — single canonical version for this iteration. Variants can be added later if a clear use case emerges.
+- **Visual regression testing for the PDF** — overkill for a single deterministic artifact; manual eyeball on first build suffices.
+- **"Site = resume" radical consolidation** — making the entire portfolio render as a resume in print mode. Larger lift, considered for future P-item if/when the markdown-resume model proves limiting.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
+        "@types/node": "^25.6.0",
         "playwright": "^1.59.1",
         "serve-handler": "^6.1.7",
         "vitest": "^4.1.5"
@@ -2483,6 +2484,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/react": {
@@ -6409,6 +6420,13 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "typescript": "^5.9.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "playwright": "^1.59.1",
         "serve-handler": "^6.1.7",
         "vitest": "^4.1.5"
@@ -1592,6 +1593,22 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/check": "^0.9.9",
         "@astrojs/react": "^5.0.2",
         "@tailwindcss/vite": "^4.2.2",
         "@types/react": "^19.2.14",
@@ -15,10 +16,60 @@
         "astro": "^6.1.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "tailwindcss": "^4.2.2"
+        "tailwindcss": "^4.2.2",
+        "typescript": "^5.9.3"
+      },
+      "devDependencies": {
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/check": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.9.tgz",
+      "integrity": "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/language-server": "^2.16.7",
+        "chokidar": "^4.0.3",
+        "kleur": "^4.1.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "astro-check": "bin/astro-check.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -35,6 +86,53 @@
       "dependencies": {
         "picomatch": "^4.0.3"
       }
+    },
+    "node_modules/@astrojs/language-server": {
+      "version": "2.16.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.7.tgz",
+      "integrity": "sha512-b64bWT74Vq/ORcSqW7TdIjjpB6hcl+Ei/lMANIUaAGlLPiYNtPTRI/j2tzvugT+LoVwfJtE2Ukq/t2OGCyEtfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.13.1",
+        "@astrojs/yaml2ts": "^0.2.3",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "@volar/kit": "~2.4.28",
+        "@volar/language-core": "~2.4.28",
+        "@volar/language-server": "~2.4.28",
+        "@volar/language-service": "~2.4.28",
+        "muggle-string": "^0.4.1",
+        "tinyglobby": "^0.2.16",
+        "volar-service-css": "0.0.70",
+        "volar-service-emmet": "0.0.70",
+        "volar-service-html": "0.0.70",
+        "volar-service-prettier": "0.0.70",
+        "volar-service-typescript": "0.0.70",
+        "volar-service-typescript-twoslash-queries": "0.0.70",
+        "volar-service-yaml": "0.0.70",
+        "vscode-html-languageservice": "^5.6.2",
+        "vscode-uri": "^3.1.0"
+      },
+      "bin": {
+        "astro-ls": "bin/nodeServer.js"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "prettier-plugin-astro": ">=0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@astrojs/language-server/node_modules/@astrojs/compiler": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "7.1.0",
@@ -115,6 +213,15 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/yaml2ts": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.3.tgz",
+      "integrity": "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -437,6 +544,61 @@
         "@clack/core": "1.1.0",
         "sisteransi": "^1.0.5"
       }
+    },
+    "node_modules/@emmetio/abbreviation": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-abbreviation": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
+      "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "node_modules/@emmetio/html-matcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "node_modules/@emmetio/scanner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+      "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+      "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.1",
@@ -1921,6 +2083,13 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -2231,6 +2400,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2239,6 +2419,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2329,6 +2516,273 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@volar/kit": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
+      "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "typesafe-path": "^0.2.2",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/language-server": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
+      "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "request-light": "^0.7.0",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/language-service": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
+      "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/emmet-helper": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+      "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+      "license": "MIT",
+      "dependencies": {
+        "emmet": "^2.4.3",
+        "jsonc-parser": "^2.3.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.15.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -2377,6 +2831,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astro": {
@@ -2556,6 +3020,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -2616,6 +3090,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2624,6 +3112,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -2943,6 +3449,28 @@
       "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
       "license": "ISC"
     },
+    "node_modules/emmet": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+      "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/scanner",
+        "./packages/abbreviation",
+        "./packages/css-abbreviation",
+        "./"
+      ],
+      "dependencies": {
+        "@emmetio/abbreviation": "^2.3.3",
+        "@emmetio/css-abbreviation": "^2.1.8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
@@ -3048,11 +3576,43 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3122,6 +3682,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/github-slugger": {
@@ -3376,6 +3945,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -3460,6 +4038,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3468,6 +4052,21 @@
       "bin": {
         "json5": "lib/cli.js"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4591,6 +5190,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -4793,6 +5398,19 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -4843,6 +5461,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prismjs": {
@@ -5079,6 +5712,30 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/request-light": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+      "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/retext": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -5275,6 +5932,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -5312,6 +5976,34 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -5324,6 +6016,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/svgo": {
@@ -5376,6 +6080,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyclip": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
@@ -5395,19 +6106,29 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -5456,6 +6177,34 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/typesafe-path": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
+      "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-auto-import-cache": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
+      "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.8"
+      }
     },
     "node_modules/ufo": {
       "version": "1.6.3",
@@ -5889,6 +6638,333 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/volar-service-css": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
+      "integrity": "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-css-languageservice": "^6.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-emmet": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.70.tgz",
+      "integrity": "sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/css-parser": "^0.4.1",
+        "@emmetio/html-matcher": "^1.3.0",
+        "@vscode/emmet-helper": "^2.9.3",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-html": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.70.tgz",
+      "integrity": "sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-html-languageservice": "^5.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-prettier": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.70.tgz",
+      "integrity": "sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0",
+        "prettier": "^2.2 || ^3.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.70.tgz",
+      "integrity": "sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==",
+      "license": "MIT",
+      "dependencies": {
+        "path-browserify": "^1.0.1",
+        "semver": "^7.6.2",
+        "typescript-auto-import-cache": "^0.3.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-nls": "^5.2.0",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript-twoslash-queries": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.70.tgz",
+      "integrity": "sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-yaml": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.70.tgz",
+      "integrity": "sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8",
+        "yaml-language-server": "~1.20.0"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-css-languageservice": {
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
+      "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-html-languageservice": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
+      "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "^3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -5908,17 +6984,133 @@
         "node": ">=4"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-language-server": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.20.0.tgz",
+      "integrity": "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "prettier": "^3.5.0",
+        "request-light": "^0.5.7",
+        "vscode-json-languageservice": "4.1.8",
+        "vscode-languageserver": "^9.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-uri": "^3.0.2",
+        "yaml": "2.7.1"
+      },
+      "bin": {
+        "yaml-language-server": "bin/yaml-language-server"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/request-light": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+      "license": "MIT"
+    },
+    "node_modules/yaml-language-server/node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yargs-parser": {
       "version": "22.0.0",
@@ -5927,6 +7119,15 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,8 @@
         "typescript": "^5.9.3"
       },
       "devDependencies": {
+        "playwright": "^1.59.1",
+        "serve-handler": "^6.1.7",
         "vitest": "^4.1.5"
       },
       "engines": {
@@ -2939,6 +2941,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.12",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
@@ -2956,6 +2965,17 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
@@ -2988,6 +3008,16 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3157,6 +3187,23 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/convert-source-map": {
@@ -5175,6 +5222,42 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "~1.33.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -5404,6 +5487,20 @@
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
     },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -5433,6 +5530,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {
@@ -5502,6 +5646,16 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/react": {
       "version": "19.2.5",
@@ -5866,6 +6020,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/serve-handler": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+      "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "mime-types": "2.1.18",
+        "minimatch": "3.1.5",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "3.3.0",
+        "range-parser": "1.2.0"
       }
     },
     "node_modules/sharp": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "build:pdf": "node scripts/generate-pdf.mjs"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@types/node": "^25.6.0",
     "playwright": "^1.59.1",
     "serve-handler": "^6.1.7",
     "vitest": "^4.1.5"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,8 @@
     "typescript": "^5.9.3"
   },
   "devDependencies": {
+    "playwright": "^1.59.1",
+    "serve-handler": "^6.1.7",
     "vitest": "^4.1.5"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,12 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
+    "@astrojs/check": "^0.9.9",
     "@astrojs/react": "^5.0.2",
     "@tailwindcss/vite": "^4.2.2",
     "@types/react": "^19.2.14",
@@ -19,6 +22,10 @@
     "astro": "^6.1.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "tailwindcss": "^4.2.2"
+    "tailwindcss": "^4.2.2",
+    "typescript": "^5.9.3"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.5"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "astro": "astro",
     "test": "vitest run",
     "test:watch": "vitest",
-    "build:pdf": "node scripts/generate-pdf.mjs"
+    "build:pdf": "node scripts/generate-pdf.mjs",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.9",
@@ -27,6 +28,7 @@
     "typescript": "^5.9.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "playwright": "^1.59.1",
     "serve-handler": "^6.1.7",
     "vitest": "^4.1.5"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  webServer: {
+    command: 'npm run preview',
+    url: 'http://localhost:4321',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+  use: {
+    baseURL: 'http://localhost:4321',
+  },
+});

--- a/frontend/scripts/generate-pdf.mjs
+++ b/frontend/scripts/generate-pdf.mjs
@@ -1,0 +1,30 @@
+// frontend/scripts/generate-pdf.mjs
+import { chromium } from 'playwright';
+import { createServer } from 'http';
+import handler from 'serve-handler';
+import { resolve } from 'path';
+
+const distPath = resolve('dist');
+const outputPath = resolve('dist', 'Rafael_Abreu_Resume.pdf');
+
+const server = createServer((req, res) => handler(req, res, { public: distPath }));
+// Port 0 = OS-assigned free port. Avoids collision with Astro's default dev port (4321).
+await new Promise((resolve) => server.listen(0, resolve));
+const { port } = server.address();
+
+const browser = await chromium.launch();
+try {
+  const page = await browser.newPage();
+  await page.goto(`http://localhost:${port}/resume`, { waitUntil: 'load' });
+  await page.emulateMedia({ media: 'print' });
+  await page.pdf({
+    path: outputPath,
+    format: 'A4',
+    printBackground: true,
+    margin: { top: '0.5in', right: '0.5in', bottom: '0.5in', left: '0.5in' },
+  });
+  console.log(`PDF written to ${outputPath}`);
+} finally {
+  await browser.close();
+  server.close();
+}

--- a/frontend/scripts/generate-pdf.mjs
+++ b/frontend/scripts/generate-pdf.mjs
@@ -8,14 +8,23 @@ const distPath = resolve('dist');
 const outputPath = resolve('dist', 'Rafael_Abreu_Resume.pdf');
 
 const server = createServer((req, res) => handler(req, res, { public: distPath }));
-// Port 0 = OS-assigned free port. Avoids collision with Astro's default dev port (4321).
-await new Promise((resolve) => server.listen(0, resolve));
+// Port 0 = OS-assigned free port. Avoids collision with Astro's default dev port (4321)
+// and guarantees availability even if a previous build leaked sockets.
+await new Promise((resolve, reject) => {
+  server.on('error', reject);
+  server.listen(0, resolve);
+});
 const { port } = server.address();
 
 const browser = await chromium.launch();
 try {
   const page = await browser.newPage();
-  await page.goto(`http://localhost:${port}/resume`, { waitUntil: 'load' });
+  // page.goto resolves on navigation completion regardless of HTTP status —
+  // explicit response.ok() check prevents PDFing a 404 page.
+  const response = await page.goto(`http://localhost:${port}/resume`, { waitUntil: 'load' });
+  if (!response || !response.ok()) {
+    throw new Error(`Failed to load /resume for PDF generation: HTTP ${response?.status() ?? 'no response'}`);
+  }
   await page.emulateMedia({ media: 'print' });
   await page.pdf({
     path: outputPath,
@@ -25,6 +34,6 @@ try {
   });
   console.log(`PDF written to ${outputPath}`);
 } finally {
-  await browser.close();
+  await browser.close().catch((err) => console.error('browser.close failed:', err));
   server.close();
 }

--- a/frontend/src/components/Nav.astro
+++ b/frontend/src/components/Nav.astro
@@ -10,7 +10,7 @@ const navItems = [
   { label: 'Contact', href: '/#contact' },
 ];
 
-const resumePath = '/Rafael_Abreu_Resume.pdf';
+const isResumePage = Astro.url.pathname === '/resume';
 ---
 
 <header class="sticky top-0 z-50 bg-base/80 backdrop-blur-md border-b border-surface-border">
@@ -32,14 +32,15 @@ const resumePath = '/Rafael_Abreu_Resume.pdf';
 
     <div class="hidden md:flex items-center gap-3">
       <ThemeToggle client:load />
-      <a
-        href={resumePath}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="px-4 py-1.5 border border-accent-indigo/40 rounded-btn text-accent-indigo text-xs tracking-wide hover:bg-accent-indigo/10 transition-colors duration-200"
-      >
-        RESUME
-      </a>
+      {!isResumePage && (
+        <a
+          href="/resume"
+          data-resume-trigger
+          class="px-4 py-1.5 border border-accent-indigo/40 rounded-btn text-accent-indigo text-xs tracking-wide hover:bg-accent-indigo/10 transition-colors duration-200"
+        >
+          RESUME
+        </a>
+      )}
       <a
         href="/#contact"
         class="px-4 py-1.5 bg-accent-indigo rounded-btn text-white text-xs tracking-wide hover:bg-accent-indigo/90 transition-colors duration-200"
@@ -48,6 +49,6 @@ const resumePath = '/Rafael_Abreu_Resume.pdf';
       </a>
     </div>
 
-    <MobileNav client:load navItems={navItems} resumePath={resumePath} />
+    <MobileNav client:load navItems={navItems} isResumePage={isResumePage} />
   </nav>
 </header>

--- a/frontend/src/components/ResumeModal.astro
+++ b/frontend/src/components/ResumeModal.astro
@@ -1,0 +1,46 @@
+---
+// frontend/src/components/ResumeModal.astro
+import { getEntry } from 'astro:content';
+import ResumeBody from './resume/ResumeBody.astro';
+
+const resume = await getEntry('resume', 'profile');
+if (!resume) throw new Error('Resume entry not found at frontend/src/content/resume/profile.md');
+---
+
+<dialog id="resume-modal" class="resume-modal">
+  <header class="resume-modal-header">
+    <div class="resume-modal-title">
+      <span class="name">{resume.data.name}</span>
+      <span class="title">{resume.data.title}</span>
+    </div>
+    <div class="resume-modal-actions">
+      <a href="/Rafael_Abreu_Resume.pdf" download class="btn-download">Download PDF</a>
+      <button type="button" class="btn-close" aria-label="Close resume">×</button>
+    </div>
+  </header>
+  <div class="resume-modal-body">
+    <ResumeBody resume={resume} />
+  </div>
+  <footer class="resume-modal-footer">
+    Contact via <a href="/#contact">contact form</a> or
+    <a href={resume.data.links.linkedin} target="_blank" rel="noopener noreferrer">LinkedIn →</a>
+  </footer>
+</dialog>
+
+<script>
+  const modal = document.getElementById('resume-modal') as HTMLDialogElement | null;
+
+  // Event delegation handles both static Astro Nav anchors and React-hydrated MobileNav buttons.
+  document.addEventListener('click', (e) => {
+    const trigger = (e.target as HTMLElement)?.closest('[data-resume-trigger]');
+    if (trigger) {
+      e.preventDefault();
+      modal?.showModal();
+    }
+  });
+
+  modal?.querySelector('.btn-close')?.addEventListener('click', () => modal.close());
+  modal?.addEventListener('click', (e) => {
+    if (e.target === modal) modal.close();
+  });
+</script>

--- a/frontend/src/components/ResumeModal.astro
+++ b/frontend/src/components/ResumeModal.astro
@@ -30,12 +30,16 @@ if (!resume) throw new Error('Resume entry not found at frontend/src/content/res
 <script>
   const modal = document.getElementById('resume-modal') as HTMLDialogElement | null;
 
-  // Event delegation handles both static Astro Nav anchors and React-hydrated MobileNav buttons.
+  // Event delegation handles both static Astro Nav anchors and React-hydrated
+  // MobileNav buttons that don't exist until after page load. Direct handlers
+  // attached at script-execution time would miss dynamic hydrated triggers.
+  // The `!modal.open` guard prevents InvalidStateError if showModal is called
+  // while already open (e.g., keyboard re-trigger).
   document.addEventListener('click', (e) => {
     const trigger = (e.target as HTMLElement)?.closest('[data-resume-trigger]');
-    if (trigger) {
+    if (trigger && modal && !modal.open) {
       e.preventDefault();
-      modal?.showModal();
+      modal.showModal();
     }
   });
 

--- a/frontend/src/components/resume/Awards.astro
+++ b/frontend/src/components/resume/Awards.astro
@@ -1,0 +1,19 @@
+---
+interface Entry { name: string; org: string; year: string; }
+interface Props { entries: Entry[]; }
+const { entries } = Astro.props;
+---
+
+{entries.length > 0 && (
+  <section class="resume-section resume-awards" aria-label="Awards & Recognition">
+    <h2 class="resume-heading">Awards &amp; Recognition</h2>
+    <ul class="resume-list">
+      {entries.map((entry) => (
+        <li>
+          <span class="resume-award-name">{entry.name}</span>
+          <span class="resume-award-meta"> — {entry.org} ({entry.year})</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+)}

--- a/frontend/src/components/resume/Certifications.astro
+++ b/frontend/src/components/resume/Certifications.astro
@@ -1,0 +1,19 @@
+---
+interface Entry { name: string; issuer: string; year: string; }
+interface Props { entries: Entry[]; }
+const { entries } = Astro.props;
+---
+
+{entries.length > 0 && (
+  <section class="resume-section resume-certifications" aria-label="Certifications">
+    <h2 class="resume-heading">Certifications</h2>
+    <ul class="resume-list">
+      {entries.map((entry) => (
+        <li>
+          <span class="resume-cert-name">{entry.name}</span>
+          <span class="resume-cert-meta"> — {entry.issuer} ({entry.year})</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+)}

--- a/frontend/src/components/resume/Education.astro
+++ b/frontend/src/components/resume/Education.astro
@@ -1,0 +1,27 @@
+---
+// frontend/src/components/resume/Education.astro
+interface Entry {
+  school: string;
+  program: string;
+  dates: string;
+}
+interface Props {
+  entries: Entry[];
+}
+const { entries } = Astro.props;
+---
+
+{entries.length > 0 && (
+  <section class="resume-section resume-education" aria-label="Education">
+    <h2 class="resume-heading">Education</h2>
+    <ul class="resume-list">
+      {entries.map((entry) => (
+        <li>
+          <span class="resume-edu-school">{entry.school}</span>
+          <span class="resume-edu-program"> — {entry.program}</span>
+          <span class="resume-edu-dates"> ({entry.dates})</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+)}

--- a/frontend/src/components/resume/Languages.astro
+++ b/frontend/src/components/resume/Languages.astro
@@ -1,0 +1,11 @@
+---
+interface Props { entries: string[]; }
+const { entries } = Astro.props;
+---
+
+{entries.length > 0 && (
+  <section class="resume-section resume-languages" aria-label="Languages">
+    <h2 class="resume-heading">Languages</h2>
+    <p class="resume-languages-list">{entries.join(' · ')}</p>
+  </section>
+)}

--- a/frontend/src/components/resume/Projects.astro
+++ b/frontend/src/components/resume/Projects.astro
@@ -1,0 +1,20 @@
+---
+interface Entry { slug: string; headline: string; }
+interface Props { entries: Entry[]; }
+const { entries } = Astro.props;
+---
+
+{entries.length > 0 && (
+  <section class="resume-section resume-projects" aria-label="Selected projects">
+    <h2 class="resume-heading">Selected Projects</h2>
+    <ul class="resume-list">
+      {entries.map((entry) => (
+        <li>
+          <a href={`/project/${entry.slug}`} class="resume-project-link">
+            {entry.headline}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </section>
+)}

--- a/frontend/src/components/resume/ResumeBody.astro
+++ b/frontend/src/components/resume/ResumeBody.astro
@@ -1,0 +1,36 @@
+---
+// frontend/src/components/resume/ResumeBody.astro
+import type { CollectionEntry } from 'astro:content';
+import Summary from './Summary.astro';
+import Skills from './Skills.astro';
+import WorkHistory from './WorkHistory.astro';
+import Education from './Education.astro';
+import Certifications from './Certifications.astro';
+import Awards from './Awards.astro';
+import Speaking from './Speaking.astro';
+import Languages from './Languages.astro';
+import Projects from './Projects.astro';
+
+interface Props {
+  resume: CollectionEntry<'resume'>;
+}
+const { resume } = Astro.props;
+const data = resume.data;
+
+const projectEntries = data.selected_projects.map((p) => ({
+  slug: p.slug.id,
+  headline: p.headline,
+}));
+---
+
+<div class="resume-body">
+  <Summary summary={data.summary} />
+  <Skills skills={data.skills} />
+  <WorkHistory entries={data.work_history} />
+  <Education entries={data.education} />
+  <Certifications entries={data.certifications} />
+  <Awards entries={data.awards_recognition} />
+  <Speaking entries={data.speaking_writing} />
+  <Languages entries={data.languages_spoken} />
+  <Projects entries={projectEntries} />
+</div>

--- a/frontend/src/components/resume/Skills.astro
+++ b/frontend/src/components/resume/Skills.astro
@@ -1,0 +1,31 @@
+---
+// frontend/src/components/resume/Skills.astro
+interface Props {
+  skills: {
+    leadership: string[];
+    technical: string[];
+    domain: string[];
+  };
+}
+const { skills } = Astro.props;
+
+const buckets: Array<{ key: keyof typeof skills; label: string }> = [
+  { key: 'leadership', label: 'Leadership' },
+  { key: 'technical', label: 'Technical' },
+  { key: 'domain', label: 'Domain' },
+];
+---
+
+<section class="resume-section resume-skills" aria-label="Skills">
+  <h2 class="resume-heading">Skills</h2>
+  {buckets.map(({ key, label }) => (
+    skills[key].length > 0 && (
+      <div class="resume-skill-bucket">
+        <h3 class="resume-skill-label">{label}</h3>
+        <ul class="resume-skill-list">
+          {skills[key].map((skill) => <li>{skill}</li>)}
+        </ul>
+      </div>
+    )
+  ))}
+</section>

--- a/frontend/src/components/resume/Speaking.astro
+++ b/frontend/src/components/resume/Speaking.astro
@@ -1,0 +1,29 @@
+---
+interface Entry {
+  type: 'talk' | 'article' | 'podcast' | 'panel';
+  title: string;
+  venue: string;
+  year: string;
+  url?: string;
+}
+interface Props { entries: Entry[]; }
+const { entries } = Astro.props;
+---
+
+{entries.length > 0 && (
+  <section class="resume-section resume-speaking" aria-label="Speaking & Writing">
+    <h2 class="resume-heading">Speaking &amp; Writing</h2>
+    <ul class="resume-list">
+      {entries.map((entry) => (
+        <li>
+          {entry.url ? (
+            <a href={entry.url} class="resume-speaking-link">{entry.title}</a>
+          ) : (
+            <span>{entry.title}</span>
+          )}
+          <span class="resume-speaking-meta"> — {entry.venue} ({entry.year})</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+)}

--- a/frontend/src/components/resume/Summary.astro
+++ b/frontend/src/components/resume/Summary.astro
@@ -1,0 +1,10 @@
+---
+interface Props {
+  summary: string;
+}
+const { summary } = Astro.props;
+---
+
+<section class="resume-section resume-summary" aria-label="Summary">
+  <p class="text-text-secondary leading-relaxed">{summary}</p>
+</section>

--- a/frontend/src/components/resume/WorkHistory.astro
+++ b/frontend/src/components/resume/WorkHistory.astro
@@ -1,0 +1,45 @@
+---
+// frontend/src/components/resume/WorkHistory.astro
+interface Entry {
+  company: string;
+  title: string;
+  dates: string;
+  location?: string;
+  tech_stack: string[];
+  bullets: string[];
+}
+
+interface Props {
+  entries: Entry[];
+}
+
+const { entries } = Astro.props;
+---
+
+<section class="resume-section resume-work-history" aria-label="Work history">
+  <h2 class="resume-heading">Experience</h2>
+  {entries.map((entry) => (
+    <article class="resume-job">
+      <header class="resume-job-header">
+        <div class="resume-job-title-row">
+          <span class="resume-job-title">{entry.title}</span>
+          <span class="resume-job-company">{entry.company}</span>
+        </div>
+        <div class="resume-job-meta">
+          <span class="resume-job-dates">{entry.dates}</span>
+          {entry.location && <span class="resume-job-location"> · {entry.location}</span>}
+        </div>
+      </header>
+      {entry.bullets.length > 0 && (
+        <ul class="resume-job-bullets">
+          {entry.bullets.map((b) => <li>{b}</li>)}
+        </ul>
+      )}
+      {entry.tech_stack.length > 0 && (
+        <div class="resume-job-tech">
+          {entry.tech_stack.map((tech) => <span class="resume-tech-tag">{tech}</span>)}
+        </div>
+      )}
+    </article>
+  ))}
+</section>

--- a/frontend/src/content.config.ts
+++ b/frontend/src/content.config.ts
@@ -1,4 +1,4 @@
-import { defineCollection, z } from 'astro:content';
+import { defineCollection, z, reference } from 'astro:content';
 import { glob } from 'astro/loaders';
 
 const projects = defineCollection({
@@ -16,4 +16,59 @@ const projects = defineCollection({
   }),
 });
 
-export const collections = { projects };
+const resume = defineCollection({
+  loader: glob({ pattern: 'profile.md', base: './src/content/resume' }),
+  schema: z.object({
+    name: z.string(),
+    title: z.string(),
+    location: z.string(),
+    links: z.object({
+      linkedin: z.string().url(),
+      github: z.string().url().optional(),
+      portfolio: z.string().url().optional(),
+    }),
+    summary: z.string(),
+    work_history: z.array(z.object({
+      company: z.string(),
+      title: z.string(),
+      dates: z.string(),
+      location: z.string().optional(),
+      tech_stack: z.array(z.string()).default([]),
+      bullets: z.array(z.string()).default([]),
+    })),
+    education: z.array(z.object({
+      school: z.string(),
+      program: z.string(),
+      dates: z.string(),
+    })),
+    certifications: z.array(z.object({
+      name: z.string(),
+      issuer: z.string(),
+      year: z.string(),
+    })).default([]),
+    skills: z.object({
+      leadership: z.array(z.string()).default([]),
+      technical: z.array(z.string()).default([]),
+      domain: z.array(z.string()).default([]),
+    }),
+    awards_recognition: z.array(z.object({
+      name: z.string(),
+      org: z.string(),
+      year: z.string(),
+    })).default([]),
+    speaking_writing: z.array(z.object({
+      type: z.enum(['talk', 'article', 'podcast', 'panel']),
+      title: z.string(),
+      venue: z.string(),
+      year: z.string(),
+      url: z.string().url().optional(),
+    })).default([]),
+    languages_spoken: z.array(z.string()).default([]),
+    selected_projects: z.array(z.object({
+      slug: reference('projects'),
+      headline: z.string(),
+    })).default([]),
+  }),
+});
+
+export const collections = { projects, resume };

--- a/frontend/src/content/resume/profile.md
+++ b/frontend/src/content/resume/profile.md
@@ -6,7 +6,7 @@ links:
   linkedin: "https://www.linkedin.com/in/rfabreu/"
   github: "https://github.com/rfabreu"
   portfolio: "https://rafaelabreu.dev"
-summary: "Operations & Infrastructure Leader with a track record of scaling teams, owning high-availability environments at scale, and driving automation that expands operational capacity. Progressed from hands-on technical roles to leading multi-shift operations organizations supporting 5,000+ concurrent real-time service streams across global clients. Builds the organizational systems — processes, teams, tooling — that enable consistent SLA delivery in complex, high-stakes environments. Industry experience includes real-time media infrastructure, though the underlying disciplines — incident response, operational scaling, cross-functional stakeholder management, and automation — apply across any 24/7 mission-critical environment."
+summary: "Operations & Infrastructure Leader and hands-on software engineer. Scales 24/7 mission-critical environments — currently leads a 16-person team supporting 5,000+ concurrent real-time service streams across global clients — while continuously shipping the automation, tooling, and full-stack systems (Go, Python, React, Next.js) that run them. Builds both the organizational systems and the technical systems they depend on. The underlying disciplines — incident response, operational scaling, cross-functional leadership, and software automation — apply across any high-availability environment, in or out of broadcast."
 work_history:
   - company: "Nextologies"
     title: "Operations Manager (VNOC)"
@@ -50,13 +50,16 @@ work_history:
     title: "Software Engineer"
     dates: "Dec 2021 – Present"
     tech_stack:
-      - "Python"
       - "Go"
-      - "JavaScript"
+      - "Python"
+      - "TypeScript"
       - "React"
+      - "Next.js"
+      - "Astro"
     bullets:
-      - "Architected and delivered internal tools, dashboards, and automation systems for operations and media workflows."
-      - "Built integrations and automation scripts that eliminated manual processes and improved operational visibility across client environments."
+      - "Designed and shipped the EBU R128 loudness analyzer: parallel Python analyzer + serverless API + React dashboard automating compliance across dozens of real-time streams."
+      - "Built a workforce coordination platform in Go and Next.js with hierarchical role-based workflows, multi-level approval chains, and an immutable audit trail."
+      - "Architected this portfolio as a full-stack monorepo (Astro frontend + Go API + Gemini AI integration + CI/CD), shipping production-grade infrastructure as a public artifact."
   - company: "FPtv Festival Portuguese Television"
     title: "Broadcast Operations Manager"
     dates: "Jun 2021 – Aug 2023"
@@ -115,7 +118,7 @@ skills:
     - "SOPs, Escalation Frameworks & Process Design"
     - "Performance Management & Team Development"
   technical:
-    - "Full Stack Development (Go, Python, JavaScript, React)"
+    - "Full Stack Development (Go, Python, JavaScript, React, Astro, Next.js)"
     - "Systems Automation & Workflow Optimization"
     - "Containerization (Docker, Kubernetes)"
     - "CI/CD & Infrastructure as Code"

--- a/frontend/src/content/resume/profile.md
+++ b/frontend/src/content/resume/profile.md
@@ -14,17 +14,17 @@ work_history:
     location: "Toronto, Canada"
     tech_stack: []
     bullets:
-      - "Led a 10+ member operations team running 24/7 across multiple shifts, supporting 5,000+ concurrent real-time service streams across global clients."
+      - "Led a 16-person operations team running 24/7 across multiple shifts, supporting 5,000+ concurrent real-time service streams across global clients."
       - "Owned operational performance, incident response, and SLA execution — setting the standard for uptime and service reliability."
       - "Drove automation and systems improvements that expanded operational capacity and reduced manual intervention at scale."
-      - "Partnered with executive leadership and cross-functional stakeholders to align operations with company growth and evolving client demands."
+      - "Led cross-departmental alignment with executive leadership and stakeholder functions, scaling operations in step with company growth and evolving client demands."
   - company: "Nextologies"
     title: "VNOC Manager"
     dates: "Feb 2025 – Jan 2026"
     location: "Toronto, Canada"
     tech_stack: []
     bullets:
-      - "Managed end-to-end operations and team execution across all shifts, establishing performance benchmarks and accountability structures."
+      - "Led a 10-person team driving end-to-end operations and execution across all shifts, establishing performance benchmarks and accountability structures."
       - "Reduced open ticket backlog by 92%, materially improving response efficiency and service reliability across the client base."
       - "Served as the primary interface with clients, partners, and internal stakeholders during incidents and escalations."
       - "Drove operational strategy, tooling improvements, and performance optimization initiatives across the organization."
@@ -34,7 +34,7 @@ work_history:
     location: "Toronto, Canada"
     tech_stack: []
     bullets:
-      - "Oversaw real-time monitoring, fault detection, and shift coordination across a 24/7 high-availability operations environment."
+      - "Led a 9-person team overseeing real-time monitoring, fault detection, and shift coordination across a 24/7 high-availability operations environment."
       - "Designed and implemented SOPs, escalation frameworks, and training systems that improved operational clarity and team alignment."
       - "Established structured onboarding and knowledge transfer processes, increasing team capability and consistency across functions."
   - company: "Nextologies"
@@ -43,7 +43,7 @@ work_history:
     location: "Toronto, Canada"
     tech_stack: []
     bullets:
-      - "Directed real-time operations across live feeds, playout systems, and signal distribution in a high-availability environment."
+      - "Led an 8-person team directing real-time operations across live feeds, playout systems, and signal distribution in a high-availability environment."
       - "Managed escalations and coordinated troubleshooting across technical teams, minimizing impact to live service delivery."
       - "Developed internal documentation and onboarding processes that improved team efficiency and reduced time-to-resolution."
   - company: "Freelance"

--- a/frontend/src/content/resume/profile.md
+++ b/frontend/src/content/resume/profile.md
@@ -1,0 +1,147 @@
+---
+name: "Rafael Abreu"
+title: "Operations & Infrastructure Leader"
+location: "Toronto, Ontario, Canada"
+links:
+  linkedin: "https://www.linkedin.com/in/rfabreu/"
+  github: "https://github.com/rfabreu"
+  portfolio: "https://rafaelabreu.dev"
+summary: "Operations & Infrastructure Leader with a track record of scaling teams, owning high-availability environments at scale, and driving automation that expands operational capacity. Progressed from hands-on technical roles to leading multi-shift operations organizations supporting 5,000+ concurrent real-time service streams across global clients. Builds the organizational systems — processes, teams, tooling — that enable consistent SLA delivery in complex, high-stakes environments. Industry experience includes real-time media infrastructure, though the underlying disciplines — incident response, operational scaling, cross-functional stakeholder management, and automation — apply across any 24/7 mission-critical environment."
+work_history:
+  - company: "Nextologies"
+    title: "Operations Manager (VNOC)"
+    dates: "Jan 2026 – Present"
+    location: "Toronto, Canada"
+    tech_stack: []
+    bullets:
+      - "Led a 10+ member operations team running 24/7 across multiple shifts, supporting 5,000+ concurrent real-time service streams across global clients."
+      - "Owned operational performance, incident response, and SLA execution — setting the standard for uptime and service reliability."
+      - "Drove automation and systems improvements that expanded operational capacity and reduced manual intervention at scale."
+      - "Partnered with executive leadership and cross-functional stakeholders to align operations with company growth and evolving client demands."
+  - company: "Nextologies"
+    title: "VNOC Manager"
+    dates: "Feb 2025 – Jan 2026"
+    location: "Toronto, Canada"
+    tech_stack: []
+    bullets:
+      - "Managed end-to-end operations and team execution across all shifts, establishing performance benchmarks and accountability structures."
+      - "Reduced open ticket backlog by 92%, materially improving response efficiency and service reliability across the client base."
+      - "Served as the primary interface with clients, partners, and internal stakeholders during incidents and escalations."
+      - "Drove operational strategy, tooling improvements, and performance optimization initiatives across the organization."
+  - company: "Nextologies"
+    title: "VNOC Supervisor"
+    dates: "Aug 2024 – Feb 2025"
+    location: "Toronto, Canada"
+    tech_stack: []
+    bullets:
+      - "Oversaw real-time monitoring, fault detection, and shift coordination across a 24/7 high-availability operations environment."
+      - "Designed and implemented SOPs, escalation frameworks, and training systems that improved operational clarity and team alignment."
+      - "Established structured onboarding and knowledge transfer processes, increasing team capability and consistency across functions."
+  - company: "Nextologies"
+    title: "NOC Supervisor (MCR)"
+    dates: "Aug 2023 – Aug 2024"
+    location: "Toronto, Canada"
+    tech_stack: []
+    bullets:
+      - "Directed real-time operations across live feeds, playout systems, and signal distribution in a high-availability environment."
+      - "Managed escalations and coordinated troubleshooting across technical teams, minimizing impact to live service delivery."
+      - "Developed internal documentation and onboarding processes that improved team efficiency and reduced time-to-resolution."
+  - company: "Freelance"
+    title: "Software Engineer"
+    dates: "Dec 2021 – Present"
+    tech_stack:
+      - "Python"
+      - "Go"
+      - "JavaScript"
+      - "React"
+    bullets:
+      - "Architected and delivered internal tools, dashboards, and automation systems for operations and media workflows."
+      - "Built integrations and automation scripts that eliminated manual processes and improved operational visibility across client environments."
+  - company: "FPtv Festival Portuguese Television"
+    title: "Broadcast Operations Manager"
+    dates: "Jun 2021 – Aug 2023"
+    tech_stack: []
+    bullets:
+      - "Led operations strategy and execution across live and recorded content delivery, overseeing consistency and quality at scale."
+      - "Drove an 80% increase in channel viewership through infrastructure improvements and operational workflow redesign."
+      - "Implemented SOPs and upgraded production systems, establishing the operational foundation for sustainable growth."
+  - company: "FPtv Festival Portuguese Television"
+    title: "Full Stack Developer"
+    dates: "Apr 2022 – Aug 2023"
+    tech_stack:
+      - "HTML"
+      - "CSS"
+      - "JavaScript"
+      - "Weebly"
+    bullets:
+      - "Developed the organization's public website, driving a 62% increase in traffic through improved architecture and user experience."
+      - "Built automation tools that accelerated content production and improved system reliability across the broadcast workflow."
+  - company: "FPtv Festival Portuguese Television"
+    title: "Broadcast & Master Control Leadership"
+    dates: "2016 – 2021"
+    tech_stack: []
+    bullets:
+      - "Led teams in master control operations for live broadcasts spanning news, sports, and large-scale events, ensuring signal integrity and uptime."
+      - "Coordinated multi-path signal delivery across regions via satellite and IP, maintaining reliability across complex real-time distribution."
+  - company: "Impact Drywall"
+    title: "IT Manager & Executive"
+    dates: "2016 – 2017"
+    tech_stack: []
+    bullets:
+      - "Led digital transformation initiatives including CRM implementation, modernizing client account management and internal systems."
+  - company: "Colégio Adélia Camargo Corrêa"
+    title: "Head of IT (CTO)"
+    dates: "2013 – 2015"
+    tech_stack: []
+    bullets:
+      - "Defined and owned IT strategy and infrastructure for the institution, partnering with enterprise providers and government programs."
+      - "Delivered large-scale education technology initiatives that expanded institutional capability and improved operational outcomes."
+education:
+  - school: "University of Toronto School of Continuing Studies"
+    program: "Certificate, Web Development"
+    dates: "2022"
+  - school: "Anderson College"
+    program: "Diploma, Business Administration"
+    dates: "2018"
+certifications:
+  - name: "Red Hat Student Education Programme Kubernetes Bootcamp"
+    issuer: "Red Hat"
+    year: "2022"
+skills:
+  leadership:
+    - "Operations Leadership & Team Scaling"
+    - "Incident Response & SLA Ownership"
+    - "Cross-Functional Stakeholder Management"
+    - "SOPs, Escalation Frameworks & Process Design"
+    - "Performance Management & Team Development"
+  technical:
+    - "Full Stack Development (Go, Python, JavaScript, React)"
+    - "Systems Automation & Workflow Optimization"
+    - "Containerization (Docker, Kubernetes)"
+    - "CI/CD & Infrastructure as Code"
+    - "Real-Time Infrastructure & Streaming Systems"
+    - "Real-Time Signal Processing & Distribution"
+  domain:
+    - "24/7 NOC / Operations Centers"
+    - "Real-Time Systems"
+    - "24/7 High-Availability Mission-Critical Environments"
+    - "Live Channel Delivery at Scale (5,000+ channels)"
+    - "EBU R128 Loudness Compliance"
+    - "Multi-Path Signal & Network Distribution"
+awards_recognition: []
+speaking_writing: []
+languages_spoken:
+  - "English (Native)"
+  - "Portuguese (Native)"
+selected_projects:
+  - slug: "portfolio"
+    headline: "Full-stack monorepo (Astro + Go + AI) demonstrating engineering depth across frontend, backend, AI integration, and CI/CD infrastructure."
+  - slug: "prjtskmngr"
+    headline: "Cross-department workforce coordination platform with hierarchical role-based workflows, multi-level approval chains, and an immutable audit trail — built in Go and Next.js."
+  - slug: "loudness-analyzer"
+    headline: "Three-tier automated compliance system replacing manual spot-checking: parallel Python analyzer, serverless API, and a React dashboard visualizing results across dozens of real-time streams."
+  - slug: "freckles-design"
+    headline: "Client-facing brand platform built in React with CI/CD deployment — product delivery from design brief to live production for a real external client."
+---
+
+Operations & Infrastructure Leader scaling teams and high-availability environments at the intersection of real-time infrastructure, automation, and operational excellence.

--- a/frontend/src/islands/MobileNav.tsx
+++ b/frontend/src/islands/MobileNav.tsx
@@ -8,10 +8,10 @@ interface NavItem {
 
 interface Props {
   navItems: NavItem[];
-  resumePath: string;
+  isResumePage: boolean;
 }
 
-export default function MobileNav({ navItems, resumePath }: Props) {
+export default function MobileNav({ navItems, isResumePage }: Props) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -50,14 +50,16 @@ export default function MobileNav({ navItems, resumePath }: Props) {
             </a>
           ))}
           <div className="flex gap-4 mt-4">
-            <a
-              href={resumePath}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="px-6 py-2 border border-accent-indigo/40 rounded-lg text-accent-indigo text-sm"
-            >
-              RESUME
-            </a>
+            {!isResumePage && (
+              <a
+                href="/resume"
+                data-resume-trigger
+                onClick={() => setIsOpen(false)}
+                className="px-6 py-2 border border-accent-indigo/40 rounded-lg text-accent-indigo text-sm"
+              >
+                RESUME
+              </a>
+            )}
             <a
               href="/#contact"
               onClick={() => setIsOpen(false)}

--- a/frontend/src/islands/ParticleHero.tsx
+++ b/frontend/src/islands/ParticleHero.tsx
@@ -116,11 +116,13 @@ const LIGHT_PALETTE = [
 const DARK_LINE_COLOR: [number, number, number] = [0.389, 0.4, 0.945];
 const LIGHT_LINE_COLOR: [number, number, number] = [0.310, 0.275, 0.898];
 
+type Palette = readonly (readonly [number, number, number])[];
+
 function isLightTheme(): boolean {
   return document.documentElement.dataset.theme === 'light';
 }
 
-function initParticles(width: number, height: number, isMobile: boolean, palette: typeof DARK_PALETTE): Particle[] {
+function initParticles(width: number, height: number, isMobile: boolean, palette: Palette): Particle[] {
   const count = Math.max(60, Math.min(120, Math.floor(width / 15)));
   const speedMultiplier = isMobile ? 1.5 : 1.0;
   const particles: Particle[] = [];

--- a/frontend/src/layouts/BaseLayout.astro
+++ b/frontend/src/layouts/BaseLayout.astro
@@ -1,14 +1,17 @@
 ---
 import '../styles/global.css';
+import ResumeModal from '../components/ResumeModal.astro';
 
 interface Props {
   title?: string;
   description?: string;
+  includeResumeModal?: boolean;
 }
 
 const {
   title = 'Rafael Abreu | Software Engineer',
   description = 'Software Engineer building intelligent systems across the full stack. Go, Python, React, and the infrastructure that connects them.',
+  includeResumeModal = true,
 } = Astro.props;
 ---
 
@@ -36,6 +39,8 @@ const {
   </head>
   <body>
     <slot />
+
+    {includeResumeModal && <ResumeModal />}
 
     <script>
       const observer = new IntersectionObserver(

--- a/frontend/src/pages/resume.astro
+++ b/frontend/src/pages/resume.astro
@@ -6,12 +6,12 @@ import ResumeBody from '../components/resume/ResumeBody.astro';
 
 const resume = await getEntry('resume', 'profile');
 if (!resume) throw new Error('Resume entry not found at frontend/src/content/resume/profile.md');
-// TODO(task-4.2): add includeResumeModal={false} to BaseLayout once the prop is defined there
 ---
 
 <BaseLayout
   title={`${resume.data.name} — Resume`}
   description={`Resume for ${resume.data.name}, ${resume.data.title}.`}
+  includeResumeModal={false}
 >
   <main class="resume-page">
     <header class="resume-page-header">

--- a/frontend/src/pages/resume.astro
+++ b/frontend/src/pages/resume.astro
@@ -1,0 +1,32 @@
+---
+// frontend/src/pages/resume.astro
+import { getEntry } from 'astro:content';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import ResumeBody from '../components/resume/ResumeBody.astro';
+
+const resume = await getEntry('resume', 'profile');
+if (!resume) throw new Error('Resume entry not found at frontend/src/content/resume/profile.md');
+// TODO(task-4.2): add includeResumeModal={false} to BaseLayout once the prop is defined there
+---
+
+<BaseLayout
+  title={`${resume.data.name} — Resume`}
+  description={`Resume for ${resume.data.name}, ${resume.data.title}.`}
+>
+  <main class="resume-page">
+    <header class="resume-page-header">
+      <h1 class="resume-page-name">{resume.data.name}</h1>
+      <p class="resume-page-title">{resume.data.title}</p>
+      <p class="resume-page-location">{resume.data.location}</p>
+      <p class="resume-page-links">
+        <a href={resume.data.links.linkedin}>LinkedIn</a>
+        {resume.data.links.github && <> · <a href={resume.data.links.github}>GitHub</a></>}
+        {resume.data.links.portfolio && <> · <a href={resume.data.links.portfolio}>Portfolio</a></>}
+      </p>
+    </header>
+    <ResumeBody resume={resume} />
+    <footer class="resume-page-footer">
+      <p>Contact via <a href="/#contact">contact form</a> or <a href={resume.data.links.linkedin}>LinkedIn</a>.</p>
+    </footer>
+  </main>
+</BaseLayout>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -145,3 +145,210 @@ html[data-theme="light"] .gradient-divider {
   opacity: 1;
   transform: translateY(0);
 }
+
+/* ===== Resume ===== */
+
+/* Page (used standalone at /resume and as the print source for the PDF) */
+.resume-page {
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  color: var(--color-text-primary);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  line-height: 1.6;
+}
+
+.resume-page-header {
+  margin-bottom: 2.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--color-surface-border);
+}
+
+.resume-page-name {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  margin-bottom: 0.25rem;
+}
+
+.resume-page-title {
+  font-size: 1.125rem;
+  color: var(--color-text-secondary);
+  margin-bottom: 0.5rem;
+}
+
+.resume-page-location,
+.resume-page-links {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+.resume-page-links a {
+  color: var(--color-accent-indigo);
+  text-decoration: none;
+}
+
+.resume-page-links a:hover { text-decoration: underline; }
+
+.resume-page-footer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-surface-border);
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+.resume-page-footer a { color: var(--color-accent-indigo); }
+
+/* Sections */
+.resume-section { margin-top: 2rem; }
+.resume-heading {
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-accent-indigo);
+  margin-bottom: 0.75rem;
+}
+
+/* Work history */
+.resume-job { margin-bottom: 1.5rem; }
+.resume-job-header { margin-bottom: 0.5rem; }
+.resume-job-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.resume-job-title { font-weight: 600; }
+.resume-job-company { color: var(--color-text-secondary); }
+.resume-job-meta {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+.resume-job-bullets {
+  list-style: disc;
+  padding-left: 1.5rem;
+  margin-top: 0.5rem;
+}
+.resume-job-bullets li { margin-bottom: 0.25rem; }
+.resume-job-tech {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin-top: 0.5rem;
+}
+.resume-tech-tag {
+  display: inline-block;
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-border);
+  border-radius: 0.25rem;
+  color: var(--color-text-secondary);
+}
+
+/* Skills */
+.resume-skill-bucket { margin-bottom: 0.75rem; }
+.resume-skill-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin-bottom: 0.25rem;
+}
+.resume-skill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem 0.75rem;
+  list-style: none;
+  padding: 0;
+}
+.resume-skill-list li { color: var(--color-text-secondary); }
+.resume-skill-list li:not(:last-child)::after {
+  content: '·';
+  margin-left: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+/* Generic list */
+.resume-list { list-style: none; padding: 0; }
+.resume-list li { margin-bottom: 0.375rem; }
+
+/* Modal */
+.resume-modal {
+  background: var(--color-base);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-surface-border);
+  border-radius: 0.75rem;
+  padding: 0;
+  max-width: 56rem;
+  width: 90vw;
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.resume-modal::backdrop {
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+}
+.resume-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--color-surface-border);
+  flex-shrink: 0;
+}
+.resume-modal-title { display: flex; flex-direction: column; }
+.resume-modal-title .name { font-weight: 700; }
+.resume-modal-title .title { font-size: 0.875rem; color: var(--color-text-muted); }
+.resume-modal-actions { display: flex; gap: 0.5rem; align-items: center; }
+.btn-download {
+  padding: 0.375rem 0.875rem;
+  background: var(--color-accent-indigo);
+  color: white;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  text-decoration: none;
+}
+.btn-download:hover { opacity: 0.9; }
+.btn-close {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  line-height: 1;
+}
+.btn-close:hover { color: var(--color-text-primary); }
+.resume-modal-body {
+  overflow-y: auto;
+  padding: 1.5rem;
+}
+.resume-modal-footer {
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--color-surface-border);
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+.resume-modal-footer a { color: var(--color-accent-indigo); }
+
+/* Print stylesheet — used by Playwright when generating the PDF */
+@media print {
+  /* Hide site chrome on the /resume page when printing */
+  header, footer.site-footer, nav { display: none !important; }
+  .resume-page { max-width: none; padding: 0; }
+  .resume-page-header { border-bottom-color: #ccc; }
+  .resume-section { page-break-inside: avoid; }
+  .resume-heading { color: #4f46e5; }
+  body { background: white; color: black; }
+  a { color: #4f46e5; text-decoration: none; }
+  .resume-tech-tag {
+    background: #f5f5f5;
+    border-color: #ddd;
+    color: #444;
+  }
+}

--- a/frontend/tests/e2e/resume.spec.ts
+++ b/frontend/tests/e2e/resume.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test('Resume button in nav opens the modal with expected content', async ({ page }) => {
+  await page.goto('/');
+  await page.locator('a:has-text("RESUME")').first().click();
+
+  const dialog = page.locator('dialog#resume-modal');
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator('.name')).toBeVisible();
+  await expect(dialog.locator('text=Download PDF')).toBeVisible();
+  await expect(dialog.locator('text=LinkedIn')).toBeVisible();
+});
+
+test('Download PDF link points to the static PDF asset', async ({ page }) => {
+  await page.goto('/');
+  await page.locator('a:has-text("RESUME")').first().click();
+  const downloadHref = await page.locator('.btn-download').getAttribute('href');
+  expect(downloadHref).toBe('/Rafael_Abreu_Resume.pdf');
+});
+
+test('Resume button is hidden on /resume page', async ({ page }) => {
+  await page.goto('/resume');
+  await expect(page.locator('a:has-text("RESUME")')).toHaveCount(0);
+});
+
+test('/resume page renders resume content directly', async ({ page }) => {
+  await page.goto('/resume');
+  await expect(page.locator('h1.resume-page-name')).toBeVisible();
+});

--- a/frontend/tests/resume-education.test.ts
+++ b/frontend/tests/resume-education.test.ts
@@ -1,0 +1,17 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { expect, test } from 'vitest';
+import Education from '../src/components/resume/Education.astro';
+
+test('Education renders school, program, and dates per entry', async () => {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Education, {
+    props: {
+      entries: [
+        { school: 'University of Toronto', program: 'Coding Bootcamp', dates: '2022 — 2023' },
+      ],
+    },
+  });
+  expect(html).toContain('University of Toronto');
+  expect(html).toContain('Coding Bootcamp');
+  expect(html).toContain('2022 — 2023');
+});

--- a/frontend/tests/resume-languages.test.ts
+++ b/frontend/tests/resume-languages.test.ts
@@ -1,0 +1,15 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { expect, test } from 'vitest';
+import Languages from '../src/components/resume/Languages.astro';
+
+test('Languages renders each entry inline; omits when empty', async () => {
+  const container = await AstroContainer.create();
+  const withEntries = await container.renderToString(Languages, {
+    props: { entries: ['English (Native)', 'Portuguese (Native)'] },
+  });
+  expect(withEntries).toContain('English (Native)');
+  expect(withEntries).toContain('Portuguese (Native)');
+
+  const empty = await container.renderToString(Languages, { props: { entries: [] } });
+  expect(empty.trim()).toBe('');
+});

--- a/frontend/tests/resume-list-sections.test.ts
+++ b/frontend/tests/resume-list-sections.test.ts
@@ -1,0 +1,47 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { expect, test } from 'vitest';
+import Certifications from '../src/components/resume/Certifications.astro';
+import Awards from '../src/components/resume/Awards.astro';
+import Speaking from '../src/components/resume/Speaking.astro';
+
+test('Certifications renders entries with name/issuer/year, omits when empty', async () => {
+  const container = await AstroContainer.create();
+  const withEntries = await container.renderToString(Certifications, {
+    props: { entries: [{ name: 'OpenShift Specialist', issuer: 'Red Hat', year: '2024' }] },
+  });
+  expect(withEntries).toContain('OpenShift Specialist');
+  expect(withEntries).toContain('Red Hat');
+  expect(withEntries).toContain('2024');
+
+  const empty = await container.renderToString(Certifications, { props: { entries: [] } });
+  expect(empty.trim()).toBe('');
+});
+
+test('Awards renders entries with name/org/year, omits when empty', async () => {
+  const container = await AstroContainer.create();
+  const withEntries = await container.renderToString(Awards, {
+    props: { entries: [{ name: 'Hackathon Winner', org: 'TechFest', year: '2025' }] },
+  });
+  expect(withEntries).toContain('Hackathon Winner');
+  expect(withEntries).toContain('TechFest');
+
+  const empty = await container.renderToString(Awards, { props: { entries: [] } });
+  expect(empty.trim()).toBe('');
+});
+
+test('Speaking renders entries with title/venue/year and link when present, omits when empty', async () => {
+  const container = await AstroContainer.create();
+  const withEntries = await container.renderToString(Speaking, {
+    props: {
+      entries: [
+        { type: 'talk', title: 'Building with Go', venue: 'GoTO Meetup', year: '2026', url: 'https://example.com/talk' },
+      ],
+    },
+  });
+  expect(withEntries).toContain('Building with Go');
+  expect(withEntries).toContain('GoTO Meetup');
+  expect(withEntries).toContain('href="https://example.com/talk"');
+
+  const empty = await container.renderToString(Speaking, { props: { entries: [] } });
+  expect(empty.trim()).toBe('');
+});

--- a/frontend/tests/resume-projects.test.ts
+++ b/frontend/tests/resume-projects.test.ts
@@ -1,0 +1,22 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { expect, test } from 'vitest';
+import Projects from '../src/components/resume/Projects.astro';
+
+test('Projects renders headline and links to case study by slug', async () => {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Projects, {
+    props: {
+      entries: [
+        { slug: 'fptv', headline: 'Glassmorphism dashboard for Toronto TV broadcaster' },
+      ],
+    },
+  });
+  expect(html).toContain('Glassmorphism dashboard for Toronto TV broadcaster');
+  expect(html).toContain('href="/project/fptv"');
+});
+
+test('Projects omits section when entries is empty', async () => {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Projects, { props: { entries: [] } });
+  expect(html.trim()).toBe('');
+});

--- a/frontend/tests/resume-skills.test.ts
+++ b/frontend/tests/resume-skills.test.ts
@@ -1,0 +1,22 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { expect, test } from 'vitest';
+import Skills from '../src/components/resume/Skills.astro';
+
+test('Skills renders each non-empty bucket with its label and items', async () => {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Skills, {
+    props: {
+      skills: {
+        leadership: ['Strategic Planning'],
+        technical: ['Go', 'Python'],
+        domain: [],
+      },
+    },
+  });
+  expect(html).toContain('Leadership');
+  expect(html).toContain('Strategic Planning');
+  expect(html).toContain('Technical');
+  expect(html).toContain('Go');
+  expect(html).toContain('Python');
+  expect(html).not.toContain('Domain');  // empty bucket skipped
+});

--- a/frontend/tests/resume-summary.test.ts
+++ b/frontend/tests/resume-summary.test.ts
@@ -1,0 +1,12 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { expect, test } from 'vitest';
+import Summary from '../src/components/resume/Summary.astro';
+
+test('Summary renders the summary text in a section element', async () => {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(Summary, {
+    props: { summary: 'Engineering leader building distributed systems.' },
+  });
+  expect(html).toContain('<section');
+  expect(html).toContain('Engineering leader building distributed systems.');
+});

--- a/frontend/tests/resume-work-history.test.ts
+++ b/frontend/tests/resume-work-history.test.ts
@@ -1,0 +1,47 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { expect, test } from 'vitest';
+import WorkHistory from '../src/components/resume/WorkHistory.astro';
+
+test('WorkHistory renders each job with title, company, dates, bullets, tech_stack', async () => {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(WorkHistory, {
+    props: {
+      entries: [
+        {
+          company: 'Nextologies',
+          title: 'Software Engineer',
+          dates: '2023 — Present',
+          location: 'Toronto, ON',
+          tech_stack: ['Go', 'Kubernetes'],
+          bullets: ['Architected the platform.'],
+        },
+      ],
+    },
+  });
+  expect(html).toContain('Nextologies');
+  expect(html).toContain('Software Engineer');
+  expect(html).toContain('2023 — Present');
+  expect(html).toContain('Toronto, ON');
+  expect(html).toContain('Architected the platform.');
+  expect(html).toContain('Go');
+  expect(html).toContain('Kubernetes');
+});
+
+test('WorkHistory handles empty bullets and missing location gracefully', async () => {
+  const container = await AstroContainer.create();
+  const html = await container.renderToString(WorkHistory, {
+    props: {
+      entries: [
+        {
+          company: 'Acme',
+          title: 'Engineer',
+          dates: '2020 — 2022',
+          tech_stack: [],
+          bullets: [],
+        },
+      ],
+    },
+  });
+  expect(html).toContain('Acme');
+  expect(html).not.toContain('<ul');  // no bullet list when empty
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import { getViteConfig } from 'astro/config';
+
+export default getViteConfig(
+  defineConfig({
+    test: {
+      globals: true,
+      environment: 'node',
+      include: ['tests/**/*.test.ts'],
+    },
+  }),
+);


### PR DESCRIPTION
## Summary

Implements P9 per spec [`docs/superpowers/specs/2026-04-30-resume-feature-design.md`](docs/superpowers/specs/2026-04-30-resume-feature-design.md). Closes #25.

- **Single source of truth:** `frontend/src/content/resume/profile.md` (Astro content collection with Zod schema, including `reference('projects')` cross-collection slug validation).
- **In-site modal:** native HTML `<dialog>` with event delegation — works for both static Astro Nav and React-hydrated MobileNav triggers, no extra hydration cost.
- **Standalone page:** `/resume` renders the same content full-page (also serves as Playwright's PDF print source).
- **Build-time PDF:** Playwright in CI generates `frontend/dist/Rafael_Abreu_Resume.pdf` (~128KB) on every deploy. Random-port server avoids collision with Astro dev port.
- **Chatbot grounding:** `SystemPrompt()` now embeds the resume + all project markdown via `go:embed`. Persona/rules blocks split into helpers; the prior hardcoded bio block is replaced by the resume itself. Fixes a latent staleness bug where the chatbot's project knowledge drifted from the actual portfolio.

## Architecture

```
frontend/src/content/resume/profile.md  ← single source of truth
        ↓                ↓                ↓
  Astro modal     Playwright PDF    Go embed → chatbot
   + /resume       (CI deploy)      (resume + projects)
```

All rendering deterministic at build time; no AI in the request path.

## What's explicitly out of scope

The full AI-driven pipeline (LinkedIn ingestion, GitHub-derived skill extraction, AI-generated bullets, accuracy validators, PR-bot suggestions) was considered during brainstorming and rejected as overkill for an artifact that changes 4–6 times/year. See spec's "Out of Scope" section for full reasoning.

## Test plan

- [ ] CI green (frontend build + PDF generation + Playwright E2E + Go tests)
- [ ] Visit deploy preview `/` → click RESUME → modal renders correctly in dark and light themes
- [ ] Click "Download PDF" inside the modal → file downloads, opens cleanly with proper layout
- [ ] Visit deploy preview `/resume` directly → page renders, RESUME nav button hidden on this route
- [ ] Open chat widget → ask "What is Rafael's most recent role?" → response reflects content from `profile.md` (currently "Operations Manager (VNOC)")
- [ ] Mobile viewport: hamburger menu → tap RESUME → modal opens
- [ ] PDF page count and layout look correct (one to two pages, no overflow)

## Coverage

- 9 Vitest snapshot tests for section components
- 6 Go tests for chatbot system prompt assembly (3 characterization + 3 new for embedded content)
- 4 Playwright E2E tests for the modal flow

## Plan

Detailed step-by-step at [`docs/superpowers/plans/2026-04-30-resume-feature.md`](docs/superpowers/plans/2026-04-30-resume-feature.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)