### PR TITLE
fix: resume modal centering + close-path bug

### DIFF
--- a/frontend/src/components/ResumeModal.astro
+++ b/frontend/src/components/ResumeModal.astro
@@ -15,7 +15,9 @@ if (!resume) throw new Error('Resume entry not found at frontend/src/content/res
     </div>
     <div class="resume-modal-actions">
       <a href="/Rafael_Abreu_Resume.pdf" download class="btn-download">Download PDF</a>
-      <button type="button" class="btn-close" aria-label="Close resume">×</button>
+      <form method="dialog" class="btn-close-form">
+        <button type="submit" class="btn-close" aria-label="Close resume">×</button>
+      </form>
     </div>
   </header>
   <div class="resume-modal-body">
@@ -43,7 +45,10 @@ if (!resume) throw new Error('Resume entry not found at frontend/src/content/res
     }
   });
 
-  modal?.querySelector('.btn-close')?.addEventListener('click', () => modal.close());
+  // Close button uses native <form method="dialog"> — no JS needed.
+  // This handler dismisses the modal when the user clicks the backdrop:
+  // a click whose target is the dialog itself (rather than any child)
+  // is, in practice, a click on the ::backdrop pseudo-element.
   modal?.addEventListener('click', (e) => {
     if (e.target === modal) modal.close();
   });

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -285,12 +285,16 @@ html[data-theme="light"] .gradient-divider {
   width: 90vw;
   max-height: 90vh;
   overflow: hidden;
-  display: flex;
   flex-direction: column;
-  /* Native <dialog> centering relies on margin:auto + inset:0; setting
-     display:flex above overrides the user-agent default, so restore it. */
+  /* Centering for the open state (display:flex below would otherwise
+     override the user-agent margin:auto default). */
   margin: auto;
-  inset: 0;
+}
+/* Scope display:flex to [open] so the UA stylesheet's display:none for
+   dialog:not([open]) applies on close — without this scoping, the dialog
+   stays visible after close() because display:flex wins on specificity. */
+.resume-modal[open] {
+  display: flex;
 }
 .resume-modal::backdrop {
   background: rgba(0, 0, 0, 0.6);
@@ -308,6 +312,7 @@ html[data-theme="light"] .gradient-divider {
 .resume-modal-title .name { font-weight: 700; }
 .resume-modal-title .title { font-size: 0.875rem; color: var(--color-text-muted); }
 .resume-modal-actions { display: flex; gap: 0.5rem; align-items: center; }
+.btn-close-form { display: contents; }
 .btn-download {
   padding: 0.375rem 0.875rem;
   background: var(--color-accent-indigo);

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -287,6 +287,10 @@ html[data-theme="light"] .gradient-divider {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  /* Native <dialog> centering relies on margin:auto + inset:0; setting
+     display:flex above overrides the user-agent default, so restore it. */
+  margin: auto;
+  inset: 0;
 }
 .resume-modal::backdrop {
   background: rgba(0, 0, 0, 0.6);

--- a/frontend/tests/e2e/resume.spec.ts
+++ b/frontend/tests/e2e/resume.spec.ts
@@ -27,3 +27,33 @@ test('/resume page renders resume content directly', async ({ page }) => {
   await page.goto('/resume');
   await expect(page.locator('h1.resume-page-name')).toBeVisible();
 });
+
+test('close button dismisses the modal', async ({ page }) => {
+  await page.goto('/');
+  await page.locator('a:has-text("RESUME")').first().click();
+  const dialog = page.locator('dialog#resume-modal');
+  await expect(dialog).toBeVisible();
+  await dialog.locator('.btn-close').click();
+  await expect(dialog).not.toBeVisible();
+});
+
+test('Escape key dismisses the modal', async ({ page }) => {
+  await page.goto('/');
+  await page.locator('a:has-text("RESUME")').first().click();
+  const dialog = page.locator('dialog#resume-modal');
+  await expect(dialog).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(dialog).not.toBeVisible();
+});
+
+test('clicking the backdrop dismisses the modal', async ({ page }) => {
+  await page.goto('/');
+  await page.locator('a:has-text("RESUME")').first().click();
+  const dialog = page.locator('dialog#resume-modal');
+  await expect(dialog).toBeVisible();
+  // Top-left of the viewport falls outside the centered dialog box.
+  // Clicks on the ::backdrop area register as e.target === modal,
+  // which the inline script catches to close.
+  await page.mouse.click(10, 10);
+  await expect(dialog).not.toBeVisible();
+});


### PR DESCRIPTION
## Summary

Two fixes plus three E2E tests recommended by PR #26 review:

1. **Centering** — visible bug after #26 shipped. `display: flex` on `.resume-modal` overrode the user-agent's `margin: auto` centering, anchoring the modal top-left. Fix: explicit `margin: auto`.

2. **Critical close bug caught by the new tests** — modal could open but **nothing could close it** (not the X button, not Escape, not backdrop clicks). Root cause: unconditional `display: flex` on `.resume-modal` was overriding the user-agent stylesheet's `display: none` for `dialog:not([open])`, so the dialog was technically closed but visually still showing. Fix: scope `display: flex` to `.resume-modal[open]`.

3. **Close button refactor** — replaced JS click handler with `<form method="dialog">` per HTML5 spec. Submit-button click auto-closes the dialog without JS. Cleaner and matches platform conventions.

## Why this matters

Without the new E2E tests, the close-path bug would have shipped to production. All 4 original E2E tests pass even with a stuck-open modal because they only cover the *open* flow. The reviewer's recommendation to add close-path coverage was the difference between catching this in CI vs catching it from users complaining about stuck modals.

## Test plan

- [ ] CI green
- [ ] Visit deploy preview → click RESUME → modal opens centered
- [ ] Click X button → modal closes
- [ ] Reopen → press Escape → modal closes
- [ ] Reopen → click outside the modal box → modal closes
- [ ] Visit \`/resume\` directly → page renders, RESUME button hidden in nav
- [ ] Light + dark themes both look right

## Coverage

7/7 Playwright E2E tests pass (4 existing + 3 new close-path tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)